### PR TITLE
PFMapAdjoint

### DIFF
--- a/nngeometry/object/map.py
+++ b/nngeometry/object/map.py
@@ -4,36 +4,33 @@ from typing import Generic, TypeVar
 import torch
 
 from nngeometry.backend.dummy import DummyGenerator
-from nngeometry.object.fspace import FMatDense
-
-from .pspace import PMatDense
-from .vector import FVector, PVector, random_pvector
+from nngeometry.object.vector import FVector, PVector, random_pvector
 
 
 class PFMap(ABC):
     # a class for objects that link the parameter space
     # to the function space, i.e. PullBack or PushForward
     # or equivalently jacobian matrices
-    def mv(self, v: PVector) -> FVector:
+    def mv(self, v):
         return self.jvp(v)
 
-    def mm(self, map: "PFMapAdjoint[PFMapDense]") -> PMatDense:
+    def mm(self, map):
         return self.batched_jvp(map)
 
     @abstractmethod
-    def jvp(self, v: PVector) -> FVector:
+    def jvp(self, v):
         pass
 
     @abstractmethod
-    def vjp(self, v: FVector) -> PVector:
+    def vjp(self, v):
         pass
 
     @abstractmethod
-    def batched_jvp(self, map: "PFMapDense") -> FMatDense:
+    def batched_jvp(self, map):
         pass
 
     @abstractmethod
-    def batched_vjp(self, map: "PFMapDense") -> PMatDense:
+    def batched_vjp(self, map):
         pass
 
     def adjoint(self):
@@ -47,10 +44,10 @@ class PFMapAdjoint(Generic[T]):
     def __init__(self, pfmap):
         self._pfmap = pfmap
 
-    def mv(self, v: FVector) -> PVector:
+    def mv(self, v):
         return self._pfmap.vjp(v)
 
-    def mm(self, map: "PFMapDense") -> PMatDense:
+    def mm(self, map):
         return self._pfmap.batched_vjp(map)
 
     def adjoint(self) -> T:
@@ -90,6 +87,8 @@ class PFMapDense(PFMap):
         return PVector(self.layer_collection, vector_repr=v_flat)
 
     def batched_jvp(self, other):
+        from nngeometry.object.fspace import FMatDense
+
         gram = torch.mm(
             self.data.view(-1, self.data.size(-1)),
             other.data.view(-1, self.other.size(-1)).t(),
@@ -100,11 +99,13 @@ class PFMapDense(PFMap):
         return FMatDense(self.layer_collection, DummyGenerator(), data=gram)
 
     def batched_vjp(self, other):
+        from nngeometry.object.fspace import PMatDense
+
         cov = torch.mm(
             self.data.view(-1, self.data.size(-1)).t(),
             other.data.view(-1, self.other.size(-1)),
         )
-        return PMatDense(self.layer_collection, vector_repr=cov)
+        return PMatDense(self.layer_collection, DummyGenerator(), data=cov)
 
     def __add__(self, other):
         return PFMapDense(

--- a/nngeometry/object/map.py
+++ b/nngeometry/object/map.py
@@ -7,6 +7,10 @@ from nngeometry.object.vector import FVector, PVector, random_pvector
 
 
 class PFMap(ABC):
+    # PFMaps are objects that link the parameter space
+    # to the function space, i.e. PullBack or PushForward
+    # (practically speaking, jacobian matrices)
+
     def __matmul__(self, other):
         if isinstance(other, PVector):
             return self.jvp(other)

--- a/nngeometry/object/map.py
+++ b/nngeometry/object/map.py
@@ -1,7 +1,12 @@
 from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
 
 import torch
 
+from nngeometry.backend.dummy import DummyGenerator
+from nngeometry.object.fspace import FMatDense
+
+from .pspace import PMatDense
 from .vector import FVector, PVector, random_pvector
 
 
@@ -9,7 +14,47 @@ class PFMap(ABC):
     # a class for objects that link the parameter space
     # to the function space, i.e. PullBack or PushForward
     # or equivalently jacobian matrices
-    pass
+    def mv(self, v: PVector) -> FVector:
+        return self.jvp(v)
+
+    def mm(self, map: "PFMapAdjoint[PFMapDense]") -> PMatDense:
+        return self.batched_jvp(map)
+
+    @abstractmethod
+    def jvp(self, v: PVector) -> FVector:
+        pass
+
+    @abstractmethod
+    def vjp(self, v: FVector) -> PVector:
+        pass
+
+    @abstractmethod
+    def batched_jvp(self, map: "PFMapDense") -> FMatDense:
+        pass
+
+    @abstractmethod
+    def batched_vjp(self, map: "PFMapDense") -> PMatDense:
+        pass
+
+    def adjoint(self):
+        return PFMapAdjoint(self)
+
+
+T = TypeVar("T", bound=PFMap)
+
+
+class PFMapAdjoint(Generic[T]):
+    def __init__(self, pfmap):
+        self._pfmap = pfmap
+
+    def mv(self, v: FVector) -> PVector:
+        return self._pfmap.vjp(v)
+
+    def mm(self, map: "PFMapDense") -> PMatDense:
+        return self._pfmap.batched_vjp(map)
+
+    def adjoint(self) -> T:
+        return self._pfmap
 
 
 class PFMapDense(PFMap):
@@ -43,6 +88,23 @@ class PFMapDense(PFMap):
             v.to_torch().view(-1),
         )
         return PVector(self.layer_collection, vector_repr=v_flat)
+
+    def batched_jvp(self, other):
+        gram = torch.mm(
+            self.data.view(-1, self.data.size(-1)),
+            other.data.view(-1, self.other.size(-1)).t(),
+        )
+        gram = gram.view(
+            self.data.size(0), self.data.size(1), self.other.size(0), self.other.size(1)
+        )
+        return FMatDense(self.layer_collection, DummyGenerator(), data=gram)
+
+    def batched_vjp(self, other):
+        cov = torch.mm(
+            self.data.view(-1, self.data.size(-1)).t(),
+            other.data.view(-1, self.other.size(-1)),
+        )
+        return PMatDense(self.layer_collection, vector_repr=cov)
 
     def __add__(self, other):
         return PFMapDense(

--- a/nngeometry/object/map.py
+++ b/nngeometry/object/map.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
 
 import torch
 
@@ -8,53 +7,59 @@ from nngeometry.object.vector import FVector, PVector, random_pvector
 
 
 class PFMap(ABC):
-    # a class for objects that link the parameter space
-    # to the function space, i.e. PullBack or PushForward
-    # or equivalently jacobian matrices
-    def mv(self, v):
-        return self.jvp(v)
+    def __matmul__(self, other):
+        if isinstance(other, PVector):
+            return self.jvp(other)
+        elif isinstance(other, PFMapAdjoint):
+            return self.batched_jvp(other.adjoint())
+        else:
+            return NotImplemented
 
-    def mm(self, map):
-        return self.batched_jvp(map)
+    def __rmatmul__(self, other):
+        return self.adjoint() @ other
 
     @abstractmethod
     def jvp(self, v):
         pass
 
     @abstractmethod
+    def batched_jvp(self, pfmap):
+        pass
+
+
+class AdjointMixin:
+    @abstractmethod
     def vjp(self, v):
         pass
 
     @abstractmethod
-    def batched_jvp(self, map):
-        pass
-
-    @abstractmethod
-    def batched_vjp(self, map):
+    def batched_vjp(self, pfmap):
         pass
 
     def adjoint(self):
         return PFMapAdjoint(self)
 
 
-T = TypeVar("T", bound=PFMap)
-
-
-class PFMapAdjoint(Generic[T]):
+class PFMapAdjoint:
     def __init__(self, pfmap):
-        self._pfmap = pfmap
+        self.pfmap = pfmap
 
-    def mv(self, v):
-        return self._pfmap.vjp(v)
+    def __matmul__(self, other):
+        if isinstance(other, FVector):
+            return self.pfmap.vjp(other)
+        elif isinstance(other, PFMap):
+            return self.pfmap.batched_vjp(other)
+        else:
+            return NotImplemented
 
-    def mm(self, map):
-        return self._pfmap.batched_vjp(map)
+    def __rmatmul__(self, other):
+        return self.adjoint() @ other
 
-    def adjoint(self) -> T:
-        return self._pfmap
+    def adjoint(self):
+        return self.pfmap
 
 
-class PFMapDense(PFMap):
+class PFMapDense(PFMap, AdjointMixin):
     def __init__(self, layer_collection, generator=None, data=None, examples=None):
         self.generator = generator
         self.layer_collection = layer_collection
@@ -86,26 +91,36 @@ class PFMapDense(PFMap):
         )
         return PVector(self.layer_collection, vector_repr=v_flat)
 
-    def batched_jvp(self, other):
+    def batched_jvp(self, pfmap):
         from nngeometry.object.fspace import FMatDense
 
+        pfmap = pfmap.to_torch()
         gram = torch.mm(
             self.data.view(-1, self.data.size(-1)),
-            other.data.view(-1, self.other.size(-1)).t(),
+            pfmap.view(-1, pfmap.size(-1)).t(),
         )
         gram = gram.view(
-            self.data.size(0), self.data.size(1), self.other.size(0), self.other.size(1)
+            self.data.size(0), self.data.size(1), pfmap.size(0), pfmap.size(1)
         )
-        return FMatDense(self.layer_collection, DummyGenerator(), data=gram)
+        return FMatDense(
+            self.layer_collection,
+            DummyGenerator(self.data.device),
+            data=gram,
+        )
 
-    def batched_vjp(self, other):
-        from nngeometry.object.fspace import PMatDense
+    def batched_vjp(self, pfmap):
+        from nngeometry.object.pspace import PMatDense
 
+        pfmap = pfmap.to_torch()
         cov = torch.mm(
             self.data.view(-1, self.data.size(-1)).t(),
-            other.data.view(-1, self.other.size(-1)),
+            pfmap.view(-1, pfmap.size(-1)),
         )
-        return PMatDense(self.layer_collection, DummyGenerator(), data=cov)
+        return PMatDense(
+            self.layer_collection,
+            DummyGenerator(self.data.device),
+            data=cov,
+        )
 
     def __add__(self, other):
         return PFMapDense(
@@ -178,6 +193,9 @@ class PFMapImplicit(PFMap):
 
     def jvp(self, v):
         return self.generator.implicit_Jv(v, self.examples, self.layer_collection)
+
+    def batched_jvp(self, pfmap):
+        raise NotImplementedError()
 
 
 def random_pfmap(layer_collection, output_size, device=None, dtype=torch.float64):

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -13,11 +13,10 @@ from nngeometry.layercollection import (
     LayerCollection,
     LinearLayer,
 )
+from nngeometry.maths import kronecker
 from nngeometry.object.map import PFMap, PFMapDense
+from nngeometry.object.vector import PVector
 from nngeometry.solve import cg
-
-from ..maths import kronecker
-from .vector import PVector
 
 
 class PMatAbstract(ABC):

--- a/nngeometry/object/vector.py
+++ b/nngeometry/object/vector.py
@@ -387,7 +387,10 @@ class PVector:
             return dot_
 
     def __matmul__(self, other):
-        return self.dot(other)
+        if isinstance(other, PVector):
+            return self.dot(other)
+        else:
+            return NotImplemented
 
     def size(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ dev=[
 [tool.coverage.run]
 omit = ["tests/*"]
 
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "@abstractmethod"
+]
+
 [tool.ruff]
 line-length = 88
 exclude = ["docs"]

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -1,15 +1,16 @@
 import torch
 from tasks import get_conv_gn_task, get_conv_task, get_fullyconnect_task
-from utils import check_tensors
 
 from nngeometry import Jacobian
 from nngeometry.backend import TorchHooksJacobianBackend
 from nngeometry.object.fspace import FMatDense
+from nngeometry.object.pspace import PMatDense
+from nngeometry.object.vector import random_fvector, random_pvector
 
 nonlinear_tasks = [get_conv_gn_task, get_fullyconnect_task, get_conv_task]
 
 
-def test_jacobian_vs_fdense():
+def test_jacobian():
     for get_task in nonlinear_tasks:
         loader, lc, parameters, model, function = get_task()
         backend = TorchHooksJacobianBackend(
@@ -18,18 +19,29 @@ def test_jacobian_vs_fdense():
         )
 
         FMat_dense = FMatDense(generator=backend, examples=loader, layer_collection=lc)
+        PMat_dense = PMatDense(generator=backend, examples=loader, layer_collection=lc)
 
         jacobian = Jacobian(
             model=model, function=function, loader=loader, layer_collection=lc
         )
-        jacobian_torch = jacobian.to_torch()
-        sj = jacobian_torch.size()
-        FMat_computed = torch.mm(
-            jacobian_torch.view(-1, sj[2]), jacobian_torch.view(-1, sj[2]).t()
+
+        dw = random_pvector(layer_collection=lc)
+        df = random_fvector(n_samples=jacobian.size(1), n_output=jacobian.size(0))
+
+        torch.testing.assert_close(
+            FMat_dense.to_torch(), (jacobian @ jacobian.adjoint()).to_torch()
+        )
+        torch.testing.assert_close(
+            PMat_dense.to_torch(),
+            (1 / jacobian.size(1) * (jacobian.adjoint() @ jacobian)).to_torch(),
+        )
+        torch.testing.assert_close(
+            jacobian.to_torch(), jacobian.adjoint().adjoint().to_torch()
         )
 
-        check_tensors(
-            FMat_computed.view(sj[0], sj[1], sj[0], sj[1]),
-            FMat_dense.to_torch(),
-            eps=1e-4,
+        torch.testing.assert_close(
+            (jacobian @ dw).to_torch(), (dw @ jacobian.adjoint()).to_torch()
+        )
+        torch.testing.assert_close(
+            (df @ jacobian).to_torch(), (jacobian.adjoint() @ df).to_torch()
         )

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from tasks import get_conv_gn_task, get_conv_task, get_fullyconnect_task
 
@@ -45,3 +46,12 @@ def test_jacobian():
         torch.testing.assert_close(
             (df @ jacobian).to_torch(), (jacobian.adjoint() @ df).to_torch()
         )
+
+        with pytest.raises(TypeError):
+            jacobian.adjoint() @ jacobian.adjoint()
+        with pytest.raises(TypeError):
+            jacobian @ jacobian
+        with pytest.raises(TypeError):
+            jacobian.adjoint() @ dw
+        with pytest.raises(TypeError):
+            df @ jacobian.adjoint()

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -96,7 +96,7 @@ def test_jacobian_pushforward_dense_linear():
         )
         dw = random_pvector(layer_collection=lc, device=device)
 
-        doutput_lin = push_forward.mv(dw)
+        doutput_lin = push_forward.jvp(dw)
 
         output_before = get_output_vector(loader, function)
         update_model(parameters, dw.to_torch())
@@ -118,7 +118,7 @@ def test_jacobian_pushforward_dense_nonlinear():
         dw = random_pvector(layer_collection=lc, device=device)
         dw = 1e-5 / dw.norm() * dw
 
-        doutput_lin = push_forward.mv(dw)
+        doutput_lin = push_forward.jvp(dw)
 
         output_before = get_output_vector(loader, function)
         update_model(parameters, dw.to_torch())
@@ -148,8 +148,8 @@ def test_jacobian_pushforward_implicit():
         )
         dw = random_pvector(layer_collection=lc, device=device)
 
-        doutput_lin_dense = dense_push_forward.mv(dw)
-        doutput_lin_implicit = implicit_push_forward.mv(dw)
+        doutput_lin_dense = dense_push_forward.jvp(dw)
+        doutput_lin_implicit = implicit_push_forward.jvp(dw)
 
         check_tensors(
             doutput_lin_dense.to_torch(),
@@ -172,8 +172,8 @@ def test_jacobian_pullback_dense():
         )
         dw = random_pvector(layer_collection=lc, device=device)
 
-        doutput_lin = push_forward.mv(dw)
-        dinput_lin = pull_back.adjoint().mv(doutput_lin)
+        doutput_lin = push_forward.jvp(dw)
+        dinput_lin = pull_back.vjp(doutput_lin)
         check_ratio(
             torch.dot(dw.to_torch(), dinput_lin.to_torch()),
             torch.norm(doutput_lin.to_torch()) ** 2,
@@ -213,7 +213,7 @@ def test_jacobian_fdense_vs_pullback():
 
             # Test vTMv
             vTMv_FMat = FMat_dense.vTMv(df)
-            Jv_pullback = pull_back.adjoint().mv(df).to_torch()
+            Jv_pullback = pull_back.vjp(df).to_torch()
             vTMv_pullforward = torch.dot(Jv_pullback, Jv_pullback)
             check_ratio(vTMv_pullforward, vTMv_FMat)
 
@@ -336,7 +336,7 @@ def test_jacobian_pdense_vs_pushforward():
 
             # Test vTMv
             vTMv_PMat = PMat_dense.vTMv(dw)
-            Jv_pushforward = push_forward.mv(dw)
+            Jv_pushforward = push_forward.jvp(dw)
             Jv_pushforward_flat = Jv_pushforward.to_torch()
             vTMv_pushforward = (
                 torch.dot(Jv_pushforward_flat.view(-1), Jv_pushforward_flat.view(-1))
@@ -346,7 +346,7 @@ def test_jacobian_pdense_vs_pushforward():
 
             # Test Mv
             Mv_PMat = PMat_dense.mv(dw)
-            Mv_pf_pb = pull_back.adjoint().mv(Jv_pushforward)
+            Mv_pf_pb = pull_back.vjp(Jv_pushforward)
             check_tensors(
                 Mv_pf_pb.to_torch() / n,
                 Mv_PMat.to_torch(),

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -96,7 +96,7 @@ def test_jacobian_pushforward_dense_linear():
         )
         dw = random_pvector(layer_collection=lc, device=device)
 
-        doutput_lin = push_forward.jvp(dw)
+        doutput_lin = push_forward.mv(dw)
 
         output_before = get_output_vector(loader, function)
         update_model(parameters, dw.to_torch())
@@ -118,7 +118,7 @@ def test_jacobian_pushforward_dense_nonlinear():
         dw = random_pvector(layer_collection=lc, device=device)
         dw = 1e-5 / dw.norm() * dw
 
-        doutput_lin = push_forward.jvp(dw)
+        doutput_lin = push_forward.mv(dw)
 
         output_before = get_output_vector(loader, function)
         update_model(parameters, dw.to_torch())
@@ -148,8 +148,8 @@ def test_jacobian_pushforward_implicit():
         )
         dw = random_pvector(layer_collection=lc, device=device)
 
-        doutput_lin_dense = dense_push_forward.jvp(dw)
-        doutput_lin_implicit = implicit_push_forward.jvp(dw)
+        doutput_lin_dense = dense_push_forward.mv(dw)
+        doutput_lin_implicit = implicit_push_forward.mv(dw)
 
         check_tensors(
             doutput_lin_dense.to_torch(),
@@ -172,8 +172,8 @@ def test_jacobian_pullback_dense():
         )
         dw = random_pvector(layer_collection=lc, device=device)
 
-        doutput_lin = push_forward.jvp(dw)
-        dinput_lin = pull_back.vjp(doutput_lin)
+        doutput_lin = push_forward.mv(dw)
+        dinput_lin = pull_back.adjoint().mv(doutput_lin)
         check_ratio(
             torch.dot(dw.to_torch(), dinput_lin.to_torch()),
             torch.norm(doutput_lin.to_torch()) ** 2,
@@ -213,7 +213,7 @@ def test_jacobian_fdense_vs_pullback():
 
             # Test vTMv
             vTMv_FMat = FMat_dense.vTMv(df)
-            Jv_pullback = pull_back.vjp(df).to_torch()
+            Jv_pullback = pull_back.adjoint().mv(df).to_torch()
             vTMv_pullforward = torch.dot(Jv_pullback, Jv_pullback)
             check_ratio(vTMv_pullforward, vTMv_FMat)
 
@@ -336,7 +336,7 @@ def test_jacobian_pdense_vs_pushforward():
 
             # Test vTMv
             vTMv_PMat = PMat_dense.vTMv(dw)
-            Jv_pushforward = push_forward.jvp(dw)
+            Jv_pushforward = push_forward.mv(dw)
             Jv_pushforward_flat = Jv_pushforward.to_torch()
             vTMv_pushforward = (
                 torch.dot(Jv_pushforward_flat.view(-1), Jv_pushforward_flat.view(-1))
@@ -346,7 +346,7 @@ def test_jacobian_pdense_vs_pushforward():
 
             # Test Mv
             Mv_PMat = PMat_dense.mv(dw)
-            Mv_pf_pb = pull_back.vjp(Jv_pushforward)
+            Mv_pf_pb = pull_back.adjoint().mv(Jv_pushforward)
             check_tensors(
                 Mv_pf_pb.to_torch() / n,
                 Mv_PMat.to_torch(),


### PR DESCRIPTION
POC of adjoint API for PFMap:
- PFMap subclasses implement the core logic (jvp/batched_jvp) and the additional logic if they support adjoint (vjp/batched_vjp)
- PFMap and PFMapAdjoint (not subclasses of each other) implements the API (.adjoint(), .matmul(), @)
