### PR TITLE
solvePFMap, mmap for pmatlowrank

### DIFF
--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -2,7 +2,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from functools import cache
+from functools import lru_cache
 
 import torch
 
@@ -1439,6 +1439,8 @@ class PMatLowRank(PMatAbstract):
             )
             self.data /= self.data.size(1) ** 0.5
 
+        self.get_eigendecomposition = lru_cache(maxsize=1)(self.get_eigendecomposition)
+
     def vTMv(self, v):
         data_mat = self.data.view(-1, self.data.size(-1))
         Av = torch.mv(data_mat, v.to_torch())
@@ -1484,7 +1486,6 @@ class PMatLowRank(PMatAbstract):
     def compute_eigendecomposition(self, impl="svd"):
         self.get_eigendecomposition(impl=impl)
 
-    @cache
     def get_eigendecomposition(self, impl="svd"):
         if impl == "svd":
             _, S, Vh = torch.linalg.svd(

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -2,7 +2,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from functools import cache, cached_property
+from functools import cache
 
 import torch
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -255,7 +255,7 @@ class PMatDense(PMatAbstract):
         if impl == "eigh":
             self.evals, self.evecs = torch.linalg.eigh(self.data)
         elif impl == "svd":
-            _, self.evals, self.evecs = torch.linalg.svd(self.data, full_matrices=True)
+            _, self.evals, self.evecs = torch.svd(self.data, some=False)
         else:
             raise NotImplementedError
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -2,6 +2,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
+from functools import cache, cached_property
 
 import torch
 
@@ -254,7 +255,7 @@ class PMatDense(PMatAbstract):
         if impl == "eigh":
             self.evals, self.evecs = torch.linalg.eigh(self.data)
         elif impl == "svd":
-            _, self.evals, self.evecs = torch.svd(self.data, some=False)
+            _, self.evals, self.evecs = torch.linalg.svd(self.data, full_matrices=True)
         else:
             raise NotImplementedError
 
@@ -1443,6 +1444,18 @@ class PMatLowRank(PMatAbstract):
         Av = torch.mv(data_mat, v.to_torch())
         return torch.dot(Av, Av)
 
+    def mapTMmap(self, pfmap, reduction="sum"):
+        data_mat = self.data.view(-1, self.data.size(-1))
+        pfmap_mat = pfmap.to_torch().view(-1, self.data.size(-1))
+        Amap = torch.mm(data_mat, pfmap_mat.t())
+        norm2 = (Amap**2).sum(dim=0).view(pfmap.size(0), pfmap.size(1))
+        if reduction == "sum":
+            return norm2.sum(dim=0)
+        elif reduction == "diag":
+            return norm2
+        else:
+            raise NotImplementedError
+
     def to_torch(self):
         # you probably don't want to do that: you are
         # loosing the benefit of having a low rank representation
@@ -1458,16 +1471,29 @@ class PMatLowRank(PMatAbstract):
         v_flat = torch.mv(data_mat.t(), torch.mv(data_mat, v.to_torch()))
         return PVector(v.layer_collection, vector_repr=v_flat)
 
-    def compute_eigendecomposition(self, impl="svd"):
+    def mmap(self, pfmap):
         data_mat = self.data.view(-1, self.data.size(-1))
+        pfmap_mat = pfmap.to_torch().view(-1, self.data.size(-1))
+        Amap = (
+            torch.mm(data_mat.t(), torch.mm(data_mat, pfmap_mat.t()))
+            .t()
+            .view(*pfmap.size())
+        )
+        return PFMapDense(self.layer_collection, generator=self.generator, data=Amap)
+
+    def compute_eigendecomposition(self):
+        pass
+
+    @cache
+    def get_eigendecomposition(self, impl="svd"):
         if impl == "svd":
-            _, sqrt_evals, self.evecs = torch.svd(data_mat, some=True)
-            self.evals = sqrt_evals**2
+            _, S, Vh = torch.linalg.svd(
+                self.data.view(-1, self.data.size(-1)), full_matrices=False
+            )
+            evals, evecs = S.flip(0) ** 2, Vh.flip(0).t()
+            return evals, evecs
         else:
             raise NotImplementedError
-
-    def get_eigendecomposition(self):
-        return self.evals, self.evecs
 
     def trace(self):
         A = torch.mm(
@@ -1487,9 +1513,26 @@ class PMatLowRank(PMatAbstract):
         if solve not in ["svd", "default"]:
             raise NotImplementedError
 
-        u, s, v = torch.svd(self.data.view(-1, self.data.size(-1)))
-        d = torch.mv(v, torch.mv(v.t(), x.to_torch()) / (s**2 + regul))
-        return PVector(x.layer_collection, vector_repr=d)
+        evals, evecs = self.get_eigendecomposition(impl="svd")
+        solution = torch.mv(evecs, torch.mv(evecs.t(), x.to_torch()) / (evals + regul))
+        return PVector(x.layer_collection, vector_repr=solution)
+
+    def solvePFMap(self, pfmap, regul=1e-8, solve="svd", **kwargs):
+        if solve not in ["svd", "default"]:
+            raise NotImplementedError
+
+        evals, evecs = self.get_eigendecomposition(impl="svd")
+
+        solution = (
+            torch.mm(
+                evecs,
+                torch.mm(evecs.t(), pfmap.to_torch().view(-1, pfmap.size(-1)).t())
+                / (evals[:, None] + regul),
+            )
+            .t()
+            .view(*pfmap.size())
+        )
+        return PFMapDense(pfmap.layer_collection, pfmap.generator, data=solution)
 
     def get_diag(self):
         return (self.data**2).sum(dim=(0, 1))

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1481,8 +1481,8 @@ class PMatLowRank(PMatAbstract):
         )
         return PFMapDense(self.layer_collection, generator=self.generator, data=Amap)
 
-    def compute_eigendecomposition(self):
-        pass
+    def compute_eigendecomposition(self, impl="svd"):
+        self.get_eigendecomposition(impl=impl)
 
     @cache
     def get_eigendecomposition(self, impl="svd"):

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -287,7 +287,8 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
-            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
+            pmat_lowrank.compute_eigendecomposition(impl=impl)
+            evals, evecs = pmat_lowrank.get_eigendecomposition()
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -287,8 +287,7 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
-            pmat_lowrank.compute_eigendecomposition(impl=impl)
-            evals, evecs = pmat_lowrank.get_eigendecomposition()
+            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -865,7 +864,7 @@ def test_jacobian_plowrank():
         mv = PMat_lowrank.mv(dw)
         check_tensors(mv_direct, mv.to_torch())
 
-        # Test vTMV
+        # Test vTMv
         check_ratio(torch.dot(mv_direct, dw.to_torch()), PMat_lowrank.vTMv(dw))
 
         # Test solve
@@ -877,6 +876,34 @@ def test_jacobian_plowrank():
         check_tensors(
             mv.to_torch(),
             mv_using_inv.to_torch(),
+            eps=1e-2,
+        )
+
+        # Test mmap
+        J = random_pfmap(layer_collection=lc, output_size=(3, 2), device=device)
+        mmap_direct = (
+            torch.mm(dense_tensor, J.to_torch().view(-1, J.to_torch().size(-1)).t())
+            .t()
+            .view(J.to_torch().shape)
+        )
+        mmap = PMat_lowrank.mmap(J)
+        check_tensors(mmap_direct, mmap.to_torch())
+
+        # Test mapTMmap
+        torch.testing.assert_close(
+            (mmap_direct * J.to_torch()).sum(dim=-1),
+            PMat_lowrank.mapTMmap(J, reduction="diag"),
+        )
+
+        # Test solve
+        # We will try to recover mv, which is in the span of the
+        # low rank matrix
+        regul = 1e-3
+        mmmap = PMat_lowrank.mmap(mmap)
+        mmap_using_inv = PMat_lowrank.solve(mmmap + regul * mmap, regul=regul)
+        check_tensors(
+            mmap.to_torch(),
+            mmap_using_inv.to_torch(),
             eps=1e-2,
         )
 

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -1,3 +1,5 @@
+import gc
+import time
 from functools import partial
 
 import pytest
@@ -287,8 +289,17 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
+            start_time_1 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
-            evals, evecs = pmat_lowrank.get_eigendecomposition()
+            end_time_1 = time.perf_counter()
+            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
+
+            start_time_2 = time.perf_counter()
+            pmat_lowrank.compute_eigendecomposition(impl=impl)
+            end_time_2 = time.perf_counter()
+
+            assert (end_time_1 - start_time_1) > 1e-3
+            assert (end_time_2 - start_time_2) < 1e-5
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -300,6 +311,14 @@ def test_jacobian_eigendecomposition_plowrank():
 
         with pytest.raises(NotImplementedError):
             pmat_lowrank.compute_eigendecomposition(impl="stupid")
+
+        # check that caching does not avoid being gced
+        check = []
+        PMatLowRank.__del__ = lambda self: check.append("deleted")
+        pmat_lowrank = None
+        gc.collect()
+
+        assert len(check) > 0
 
 
 def test_jacobian_pdense_vs_pushforward():

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -896,6 +896,11 @@ def test_jacobian_plowrank():
             PMat_lowrank.mapTMmap(J, reduction="diag"),
         )
 
+        torch.testing.assert_close(
+            (mmap_direct * J.to_torch()).sum(dim=(0, 2)),
+            PMat_lowrank.mapTMmap(J, reduction="sum"),
+        )
+
         # Test solve
         # We will try to recover mv, which is in the span of the
         # low rank matrix
@@ -907,6 +912,11 @@ def test_jacobian_plowrank():
             mmap_using_inv.to_torch(),
             eps=1e-2,
         )
+
+        with pytest.raises(RuntimeError):
+            PMat_lowrank.solve(mmap, 1e-8, solve="prout")
+        with pytest.raises(RuntimeError):
+            PMat_lowrank.solve(dw, 1e-8, solve="prout")
 
         # Test inv TODO
 

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -292,14 +292,13 @@ def test_jacobian_eigendecomposition_plowrank():
             start_time_1 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
             end_time_1 = time.perf_counter()
+            compute_eig_init = end_time_1 - start_time_1
             evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
 
             start_time_2 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
             end_time_2 = time.perf_counter()
-
-            assert (end_time_1 - start_time_1) > 1e-3
-            assert (end_time_2 - start_time_2) < 1e-5
+            compute_eig_cached = end_time_2 - start_time_2
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -311,6 +310,8 @@ def test_jacobian_eigendecomposition_plowrank():
 
         with pytest.raises(NotImplementedError):
             pmat_lowrank.compute_eigendecomposition(impl="stupid")
+
+        assert compute_eig_cached < compute_eig_init
 
         # check that caching does not avoid being gced
         check = []


### PR DESCRIPTION
I changed the behaviour of compute/get_eigendecomposition so that it can be use to cache computation in a transparent manner for the user when solving multiple different problems. Personally, i would prefer if the api was just .eigendecomposition() with caching instead of having compute/get (but it would break the public API for different PMat).

It was easier to use the svd decomposition of X to compute regularized inverse and/or pseudo inverse, but the QR decomposition of X could be used also (and it would be faster), as solve on the gram matrix XX^T with woodburry.

For the solve methods, i don't know how the user could asked for lstsq/ridge easily via the "solve" kwarg, as it is already used to choose the implementation of the eigendecomposition.

should there be a solve and lstsq method on PMats ?