### PR TITLE
solve and matmul on FMatDense 

### DIFF
--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
-from functools import cache
+from functools import lru_cache
 
 import torch
 
@@ -65,6 +65,8 @@ class FMatDense(FMatAbstract):
             self.data = data
         else:
             self.data = generator.get_gram_matrix(examples, layer_collection)
+
+        self._cholesky = lru_cache(maxsize=1)(self._cholesky)
 
     def mv(self, v):
         s = self.data.size()
@@ -191,7 +193,6 @@ class FMatDense(FMatAbstract):
             ).view(*s),
         )
 
-    @cache
     def _cholesky(self, regul=1e-8):
         s = self.data.size()
         return torch.linalg.cholesky(

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -51,7 +51,7 @@ class FMatAbstract(ABC):
         elif isinstance(x, FMatDense):
             return self.solveFMat(x, regul=regul, solve=solve, **kwargs)
         else:
-            raise NotImplementedError("`x` should be an instance of PVector or PFMap")
+            raise NotImplementedError("`x` should be an instance of FVector or FMat")
 
 
 class FMatDense(FMatAbstract):
@@ -196,11 +196,7 @@ class FMatDense(FMatAbstract):
         else:
             raise NotImplementedError
 
-        return FVector(
-            layer_collection=self.layer_collection,
-            generator=self.generator,
-            data=solution.view(s[0], s[1]),
-        )
+        return FVector(vector_repr=solution.view(s[0], s[1]))
 
     def solveFMat(self, fmat, regul=1e-8, solve="default"):
         s = self.data.size()

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -4,7 +4,8 @@ from functools import cache
 
 import torch
 
-from .vector import FVector, PVector
+from nngeometry.object.map import PFMap, PFMapDense
+from nngeometry.object.vector import FVector
 
 
 class FMatAbstract(ABC):
@@ -15,8 +16,10 @@ class FMatAbstract(ABC):
     def __matmul__(self, other):
         if isinstance(other, FVector):
             return self.mv(other)
-        elif isinstance(other, FMatAbstract):
+        elif isinstance(other, type(self)):
             return self.mm(other)
+        elif isinstance(other, PFMap):
+            return self.mmap(other)
         else:
             return NotImplemented
 
@@ -78,6 +81,17 @@ class FMatDense(FMatAbstract):
             self.layer_collection,
             self.generator,
             data=torch.mm(M, N).view(sM[0], sM[1], sN[2], sN[3]),
+        )
+
+    def mmap(self, pfmap):
+        sM = self.data.size()
+        M = self.data.view(-1, sM[2] * sM[3])
+        sJ = pfmap.size()
+        J = pfmap.to_torch().view(sJ[0] * sJ[1], -1)
+        return PFMapDense(
+            self.layer_collection,
+            self.generator,
+            data=torch.mm(M, J).view(sM[0], sM[1], sJ[2]),
         )
 
     def frobenius_norm(self):

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -20,14 +20,12 @@ class FMatAbstract(ABC):
         else:
             return NotImplemented
 
-    # assumes symetric self FMat by default
+    # assumes symetric by default
+    def adjoint(self):
+        return self
+
     def __rmatmul__(self, other):
-        if isinstance(other, FVector):
-            return self.mv(other)
-        elif isinstance(other, FMatAbstract):
-            return other.mm(self)
-        else:
-            return NotImplemented
+        return self.adjoint() @ other
 
     @abstractmethod
     def solveFVec(self, x, regul, solve, **kwargs):
@@ -127,10 +125,6 @@ class FMatDense(FMatAbstract):
             self.generator,
             data=self.data.permute(2, 3, 0, 1),
         )
-
-    # assumes not symetric (only for FVector)
-    def __rmatmul__(self, other):
-        return self.adjoint() @ other
 
     def vTMv(self, v):
         return v @ self.mv(v)

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -20,6 +20,7 @@ class FMatAbstract(ABC):
         else:
             return NotImplemented
 
+    # assumes symetric self FMat by default
     def __rmatmul__(self, other):
         if isinstance(other, FVector):
             return self.mv(other)
@@ -64,20 +65,6 @@ class FMatDense(FMatAbstract):
         else:
             self.data = generator.get_gram_matrix(examples, layer_collection)
 
-    def compute_eigendecomposition(self, impl="eigh"):
-        s = self.data.size()
-        M = self.data.view(s[0] * s[1], s[2] * s[3])
-        if impl == "eigh":
-            self.evals, self.evecs = torch.linalg.eigh(M)
-        elif impl == "svd":
-            _, S, Vh = torch.linalg.svd(M, full_matrices=True)
-            self.evals, self.evecs = S.flip(0), Vh.flip(0).t()
-        else:
-            raise NotImplementedError
-
-    def get_eigendecomposition(self):
-        return self.evals, self.evecs
-
     def mv(self, v):
         s = self.data.size()
         M = self.data.view(s[0] * s[1], s[2] * s[3])
@@ -95,11 +82,6 @@ class FMatDense(FMatAbstract):
             data=torch.mm(M, N).view(sM[0], sM[1], sN[2], sN[3]),
         )
 
-    def vTMv(self, v):
-        s = self.data.size()
-        v_flat = v.to_torch().view(-1)
-        return torch.dot(v_flat, torch.mv(self.data.view(-1, s[2] * s[3]), v_flat))
-
     def frobenius_norm(self):
         warnings.warn(
             """Use norm(ord="fro") instead""", DeprecationWarning, stacklevel=2
@@ -112,23 +94,8 @@ class FMatDense(FMatAbstract):
         else:  # what should we do for 4D tensor ?
             raise RuntimeError(f"Order {ord} not supported.")
 
-    def project_to_diag(self, v):
-        # TODO: test
-        return PVector(
-            model=v.model,
-            vector_repr=torch.mv(self.evecs.t(), v.to_torch()),
-        )
-
-    def project_from_diag(self, v):
-        # TODO: test
-        return PVector(model=v.model, vector_repr=torch.mv(self.evecs, v.to_torch()))
-
     def size(self, *args):
         return self.data.size(*args)
-
-    def trace(self):
-        s = self.data.size()
-        return torch.trace(self.data.view(s[0] * s[1], s[2] * s[3]))
 
     def to_torch(self):
         return self.data
@@ -153,6 +120,41 @@ class FMatDense(FMatAbstract):
             generator=self.generator,
             data=other * self.data,
         )
+
+    def adjoint(self):
+        return FMatDense(
+            self.layer_collection,
+            self.generator,
+            data=self.data.permute(2, 3, 0, 1),
+        )
+
+    # assumes not symetric (only for FVector)
+    def __rmatmul__(self, other):
+        return self.adjoint() @ other
+
+    def vTMv(self, v):
+        return v @ self.mv(v)
+
+    def mTMm(self, fmat):
+        return fmat.adjoint() @ self.mm(fmat)
+
+    def compute_eigendecomposition(self, impl="eigh"):
+        s = self.data.size()
+        M = self.data.view(s[0] * s[1], s[2] * s[3])
+        if impl == "eigh":
+            self.evals, self.evecs = torch.linalg.eigh(M)
+        elif impl == "svd":
+            _, S, Vh = torch.linalg.svd(M, full_matrices=True)
+            self.evals, self.evecs = S.flip(0), Vh.flip(0).t()
+        else:
+            raise NotImplementedError
+
+    def get_eigendecomposition(self):
+        return self.evals, self.evecs
+
+    def trace(self):
+        s = self.data.size()
+        return torch.trace(self.data.view(s[0] * s[1], s[2] * s[3]))
 
     def __pow__(self, other):
         s = self.data.size()
@@ -197,6 +199,8 @@ class FMatDense(FMatAbstract):
         v_flat = v.to_torch().view(-1, 1)
         if solve in ["default", "solve"]:
             solution = torch.cholesky_solve(v_flat, self._cholesky(regul))
+        else:
+            raise NotImplementedError
 
         return FVector(
             layer_collection=self.layer_collection,
@@ -210,6 +214,8 @@ class FMatDense(FMatAbstract):
         K = fmat.to_torch().view(sK[0] * sK[1], -1)
         if solve in ["default", "solve"]:
             solution = torch.cholesky_solve(K, self._cholesky(regul))
+        else:
+            raise NotImplementedError
 
         return FMatDense(
             layer_collection=self.layer_collection,

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -66,8 +66,6 @@ class FMatDense(FMatAbstract):
         else:
             self.data = generator.get_gram_matrix(examples, layer_collection)
 
-        self._cholesky = lru_cache(maxsize=1)(self._cholesky)
-
     def mv(self, v):
         s = self.data.size()
         M = self.data.view(s[0] * s[1], s[2] * s[3])
@@ -178,30 +176,31 @@ class FMatDense(FMatAbstract):
 
     def inv(self, regul=1e-8):
         s = self.data.size()
+        Minv = torch.cholesky_inverse(self._cholesky(regul))
+
         return FMatDense(
             layer_collection=self.layer_collection,
             generator=self.generator,
-            data=torch.linalg.inv(
-                self.data.view(s[0] * s[1], s[2] * s[3])
-                + (regul * s[1])
-                * torch.eye(
-                    s[0] * s[1],
-                    s[2] * s[3],
-                    dtype=self.data.dtype,
-                    device=self.data.device,
-                )
-            ).view(*s),
+            data=Minv.view(*s),
         )
 
     def _cholesky(self, regul=1e-8):
-        s = self.data.size()
-        return torch.linalg.cholesky(
-            self.data.view(s[0] * s[1], s[2] * s[3])
-            + (regul * s[1])
-            * torch.eye(
-                s[0] * s[1], s[2] * s[3], device=self.data.device, dtype=self.data.dtype
+        try:
+            assert self._cholesky_regul == regul
+            L = self._cholesky_factor
+        except (AttributeError, AssertionError):
+            s = self.data.size()
+
+            L = torch.linalg.cholesky(
+                self.data.view(s[0] * s[1], s[2] * s[3])
+                + (regul * s[1])
+                * torch.eye(s[0] * s[1], device=self.data.device, dtype=self.data.dtype)
             )
-        )
+
+            self._cholesky_regul = regul
+            self._cholesky_factor = L
+
+        return L
 
     def solveFVec(self, v, regul=1e-8, solve="default"):
         s = self.data.size()

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -1,5 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
+from functools import cache
 
 import torch
 
@@ -8,8 +9,50 @@ from .vector import FVector, PVector
 
 class FMatAbstract(ABC):
     @abstractmethod
-    def __init__(self, generator):
-        return NotImplementedError
+    def __init__(self, layer_collection, generator, data=None, examples=None):
+        pass
+
+    def __matmul__(self, other):
+        if isinstance(other, FVector):
+            return self.mv(other)
+        elif isinstance(other, FMatAbstract):
+            return self.mm(other)
+        else:
+            return NotImplemented
+
+    def __rmatmul__(self, other):
+        if isinstance(other, FVector):
+            return self.mv(other)
+        elif isinstance(other, FMatAbstract):
+            return other.mm(self)
+        else:
+            return NotImplemented
+
+    @abstractmethod
+    def solveFVec(self, x, regul, solve, **kwargs):
+        pass
+
+    @abstractmethod
+    def solveFMat(self, x, regul, solve, **kwargs):
+        pass
+
+    def solve(self, x, regul=1e-8, solve="default", **kwargs):
+        """
+        Solves Kx = b in x
+
+        :param regul: regularization, depending of the type of solve (e.g. Tikhonov damping,
+            or high-pass filter)
+        :type regul: float
+        :param b: b
+        :type b: FVector or FMat
+        :param solve: solve implementation, this is dependent on the FMat representation
+        """
+        if isinstance(x, FVector):
+            return self.solveFVec(x, regul=regul, solve=solve, **kwargs)
+        elif isinstance(x, FMatDense):
+            return self.solveFMat(x, regul=regul, solve=solve, **kwargs)
+        else:
+            raise NotImplementedError("`x` should be an instance of PVector or PFMap")
 
 
 class FMatDense(FMatAbstract):
@@ -27,21 +70,35 @@ class FMatDense(FMatAbstract):
         if impl == "eigh":
             self.evals, self.evecs = torch.linalg.eigh(M)
         elif impl == "svd":
-            _, self.evals, self.evecs = torch.svd(M, some=False)
+            _, S, Vh = torch.linalg.svd(M, full_matrices=True)
+            self.evals, self.evecs = S.flip(0), Vh.flip(0).t()
         else:
             raise NotImplementedError
 
+    def get_eigendecomposition(self):
+        return self.evals, self.evecs
+
     def mv(self, v):
-        # TODO: test
-        v_flat = torch.mv(self.data, v.to_torch())
-        return FVector(vector_repr=v_flat)
+        s = self.data.size()
+        M = self.data.view(s[0] * s[1], s[2] * s[3])
+        v_flat = v.to_torch().view(-1)
+        return FVector(vector_repr=torch.mv(M, v_flat).view(s[0], s[1]))
+
+    def mm(self, fmat):
+        sM = self.data.size()
+        M = self.data.view(-1, sM[2] * sM[3])
+        sN = fmat.data.size()
+        N = fmat.data.view(sN[0] * sN[1], -1)
+        return FMatDense(
+            self.layer_collection,
+            self.generator,
+            data=torch.mm(M, N).view(sM[0], sM[1], sN[2], sN[3]),
+        )
 
     def vTMv(self, v):
+        s = self.data.size()
         v_flat = v.to_torch().view(-1)
-        sd = self.data.size()
-        return torch.dot(
-            v_flat, torch.mv(self.data.view(sd[0] * sd[1], sd[2] * sd[3]), v_flat)
-        )
+        return torch.dot(v_flat, torch.mv(self.data.view(-1, s[2] * s[3]), v_flat))
 
     def frobenius_norm(self):
         warnings.warn(
@@ -66,27 +123,96 @@ class FMatDense(FMatAbstract):
         # TODO: test
         return PVector(model=v.model, vector_repr=torch.mv(self.evecs, v.to_torch()))
 
-    def get_eigendecomposition(self):
-        # TODO: test
-        return self.evals, self.evecs
-
     def size(self, *args):
-        # TODO: test
         return self.data.size(*args)
 
     def trace(self):
-        # TODO: test
-        return torch.trace(self.data)
+        s = self.data.size()
+        return torch.trace(self.data.view(s[0] * s[1], s[2] * s[3]))
 
     def to_torch(self):
         return self.data
 
     def __add__(self, other):
-        # TODO: test
-        sum_data = self.data + other.data
-        return FMatDense(generator=self.generator, data=sum_data)
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=self.data + other.data,
+        )
 
     def __sub__(self, other):
-        # TODO: test
-        sub_data = self.data - other.data
-        return FMatDense(generator=self.generator, data=sub_data)
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=self.data - other.data,
+        )
+
+    def __rmul__(self, other):
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=other * self.data,
+        )
+
+    def __pow__(self, other):
+        s = self.data.size()
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=torch.linalg.matrix_power(
+                self.data.view(s[0] * s[1], s[2] * s[3]), other
+            ).view(*s),
+        )
+
+    def inv(self, regul=1e-8):
+        s = self.data.size()
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=torch.linalg.inv(
+                self.data.view(s[0] * s[1], s[2] * s[3])
+                + (regul * s[1])
+                * torch.eye(
+                    s[0] * s[1],
+                    s[2] * s[3],
+                    dtype=self.data.dtype,
+                    device=self.data.device,
+                )
+            ).view(*s),
+        )
+
+    @cache
+    def _cholesky(self, regul=1e-8):
+        s = self.data.size()
+        return torch.linalg.cholesky(
+            self.data.view(s[0] * s[1], s[2] * s[3])
+            + (regul * s[1])
+            * torch.eye(
+                s[0] * s[1], s[2] * s[3], device=self.data.device, dtype=self.data.dtype
+            )
+        )
+
+    def solveFVec(self, v, regul=1e-8, solve="default"):
+        s = self.data.size()
+        v_flat = v.to_torch().view(-1, 1)
+        if solve in ["default", "solve"]:
+            solution = torch.cholesky_solve(v_flat, self._cholesky(regul))
+
+        return FVector(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=solution.view(s[0], s[1]),
+        )
+
+    def solveFMat(self, fmat, regul=1e-8, solve="default"):
+        s = self.data.size()
+        sK = fmat.size()
+        K = fmat.to_torch().view(sK[0] * sK[1], -1)
+        if solve in ["default", "solve"]:
+            solution = torch.cholesky_solve(K, self._cholesky(regul))
+
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=solution.view(s[0], s[1], sK[2], sK[3]),
+        )

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -66,6 +66,20 @@ class FMatDense(FMatAbstract):
         else:
             self.data = generator.get_gram_matrix(examples, layer_collection)
 
+    def compute_eigendecomposition(self, impl="eigh"):
+        s = self.data.size()
+        M = self.data.view(s[0] * s[1], s[2] * s[3])
+        if impl == "eigh":
+            self.evals, self.evecs = torch.linalg.eigh(M)
+        elif impl == "svd":
+            _, S, Vh = torch.linalg.svd(M, full_matrices=True)
+            self.evals, self.evecs = S.flip(0), Vh.flip(0).t()
+        else:
+            raise NotImplementedError
+
+    def get_eigendecomposition(self):
+        return self.evals, self.evecs
+
     def mv(self, v):
         s = self.data.size()
         M = self.data.view(s[0] * s[1], s[2] * s[3])
@@ -94,6 +108,12 @@ class FMatDense(FMatAbstract):
             data=torch.mm(M, J).view(sM[0], sM[1], sJ[2]),
         )
 
+    def vTMv(self, v):
+        return v @ self.mv(v)
+
+    def mTMm(self, fmat):
+        return fmat.adjoint() @ self.mm(fmat)
+
     def frobenius_norm(self):
         warnings.warn(
             """Use norm(ord="fro") instead""", DeprecationWarning, stacklevel=2
@@ -109,8 +129,19 @@ class FMatDense(FMatAbstract):
     def size(self, *args):
         return self.data.size(*args)
 
+    def trace(self):
+        s = self.data.size()
+        return torch.trace(self.data.view(s[0] * s[1], s[2] * s[3]))
+
     def to_torch(self):
         return self.data
+
+    def adjoint(self):
+        return FMatDense(
+            self.layer_collection,
+            self.generator,
+            data=self.data.permute(2, 3, 0, 1),
+        )
 
     def __add__(self, other):
         return FMatDense(
@@ -133,37 +164,6 @@ class FMatDense(FMatAbstract):
             data=other * self.data,
         )
 
-    def adjoint(self):
-        return FMatDense(
-            self.layer_collection,
-            self.generator,
-            data=self.data.permute(2, 3, 0, 1),
-        )
-
-    def vTMv(self, v):
-        return v @ self.mv(v)
-
-    def mTMm(self, fmat):
-        return fmat.adjoint() @ self.mm(fmat)
-
-    def compute_eigendecomposition(self, impl="eigh"):
-        s = self.data.size()
-        M = self.data.view(s[0] * s[1], s[2] * s[3])
-        if impl == "eigh":
-            self.evals, self.evecs = torch.linalg.eigh(M)
-        elif impl == "svd":
-            _, S, Vh = torch.linalg.svd(M, full_matrices=True)
-            self.evals, self.evecs = S.flip(0), Vh.flip(0).t()
-        else:
-            raise NotImplementedError
-
-    def get_eigendecomposition(self):
-        return self.evals, self.evecs
-
-    def trace(self):
-        s = self.data.size()
-        return torch.trace(self.data.view(s[0] * s[1], s[2] * s[3]))
-
     def __pow__(self, other):
         s = self.data.size()
         return FMatDense(
@@ -172,16 +172,6 @@ class FMatDense(FMatAbstract):
             data=torch.linalg.matrix_power(
                 self.data.view(s[0] * s[1], s[2] * s[3]), other
             ).view(*s),
-        )
-
-    def inv(self, regul=1e-8):
-        s = self.data.size()
-        Minv = torch.cholesky_inverse(self._cholesky(regul))
-
-        return FMatDense(
-            layer_collection=self.layer_collection,
-            generator=self.generator,
-            data=Minv.view(*s),
         )
 
     def _cholesky(self, regul=1e-8):
@@ -201,6 +191,16 @@ class FMatDense(FMatAbstract):
             self._cholesky_factor = L
 
         return L
+
+    def inv(self, regul=1e-8):
+        s = self.data.size()
+        Minv = torch.cholesky_inverse(self._cholesky(regul))
+
+        return FMatDense(
+            layer_collection=self.layer_collection,
+            generator=self.generator,
+            data=Minv.view(*s),
+        )
 
     def solveFVec(self, v, regul=1e-8, solve="default"):
         s = self.data.size()

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -1,6 +1,5 @@
 import warnings
 from abc import ABC, abstractmethod
-from functools import lru_cache
 
 import torch
 
@@ -22,13 +21,6 @@ class FMatAbstract(ABC):
             return self.mmap(other)
         else:
             return NotImplemented
-
-    # assumes symetric by default
-    def adjoint(self):
-        return self
-
-    def __rmatmul__(self, other):
-        return self.adjoint() @ other
 
     @abstractmethod
     def solveFVec(self, x, regul, solve, **kwargs):
@@ -108,12 +100,6 @@ class FMatDense(FMatAbstract):
             data=torch.mm(M, J).view(sM[0], sM[1], sJ[2]),
         )
 
-    def vTMv(self, v):
-        return v @ self.mv(v)
-
-    def mTMm(self, fmat):
-        return fmat.adjoint() @ self.mm(fmat)
-
     def frobenius_norm(self):
         warnings.warn(
             """Use norm(ord="fro") instead""", DeprecationWarning, stacklevel=2
@@ -135,13 +121,6 @@ class FMatDense(FMatAbstract):
 
     def to_torch(self):
         return self.data
-
-    def adjoint(self):
-        return FMatDense(
-            self.layer_collection,
-            self.generator,
-            data=self.data.permute(2, 3, 0, 1),
-        )
 
     def __add__(self, other):
         return FMatDense(

--- a/nngeometry/object/fspace.py
+++ b/nngeometry/object/fspace.py
@@ -15,8 +15,6 @@ class FMatAbstract(ABC):
     def __matmul__(self, other):
         if isinstance(other, FVector):
             return self.mv(other)
-        elif isinstance(other, type(self)):
-            return self.mm(other)
         elif isinstance(other, PFMap):
             return self.mmap(other)
         else:
@@ -27,7 +25,7 @@ class FMatAbstract(ABC):
         pass
 
     @abstractmethod
-    def solveFMat(self, x, regul, solve, **kwargs):
+    def solvePFMap(self, x, regul, solve, **kwargs):
         pass
 
     def solve(self, x, regul=1e-8, solve="default", **kwargs):
@@ -38,15 +36,17 @@ class FMatAbstract(ABC):
             or high-pass filter)
         :type regul: float
         :param b: b
-        :type b: FVector or FMat
+        :type b: FVector or PFMap
         :param solve: solve implementation, this is dependent on the FMat representation
         """
         if isinstance(x, FVector):
             return self.solveFVec(x, regul=regul, solve=solve, **kwargs)
-        elif isinstance(x, FMatDense):
-            return self.solveFMat(x, regul=regul, solve=solve, **kwargs)
+        elif isinstance(x, PFMapDense):
+            return self.solvePFMap(x, regul=regul, solve=solve, **kwargs)
         else:
-            raise NotImplementedError("`x` should be an instance of FVector or FMat")
+            raise NotImplementedError(
+                "`x` should be an instance of FVector or PFMap"
+            )
 
 
 class FMatDense(FMatAbstract):
@@ -77,17 +77,6 @@ class FMatDense(FMatAbstract):
         M = self.data.view(s[0] * s[1], s[2] * s[3])
         v_flat = v.to_torch().view(-1)
         return FVector(vector_repr=torch.mv(M, v_flat).view(s[0], s[1]))
-
-    def mm(self, fmat):
-        sM = self.data.size()
-        M = self.data.view(-1, sM[2] * sM[3])
-        sN = fmat.data.size()
-        N = fmat.data.view(sN[0] * sN[1], -1)
-        return FMatDense(
-            self.layer_collection,
-            self.generator,
-            data=torch.mm(M, N).view(sM[0], sM[1], sN[2], sN[3]),
-        )
 
     def mmap(self, pfmap):
         sM = self.data.size()
@@ -143,16 +132,6 @@ class FMatDense(FMatAbstract):
             data=other * self.data,
         )
 
-    def __pow__(self, other):
-        s = self.data.size()
-        return FMatDense(
-            layer_collection=self.layer_collection,
-            generator=self.generator,
-            data=torch.linalg.matrix_power(
-                self.data.view(s[0] * s[1], s[2] * s[3]), other
-            ).view(*s),
-        )
-
     def _cholesky(self, regul=1e-8):
         try:
             assert self._cholesky_regul == regul
@@ -191,17 +170,17 @@ class FMatDense(FMatAbstract):
 
         return FVector(vector_repr=solution.view(s[0], s[1]))
 
-    def solveFMat(self, fmat, regul=1e-8, solve="default"):
+    def solvePFMap(self, pfmap, regul=1e-8, solve="default"):
         s = self.data.size()
-        sK = fmat.size()
-        K = fmat.to_torch().view(sK[0] * sK[1], -1)
+        sJ = pfmap.size()
+        J = pfmap.to_torch().view(sJ[0] * sJ[1], -1)
         if solve in ["default", "solve"]:
-            solution = torch.cholesky_solve(K, self._cholesky(regul))
+            solution = torch.cholesky_solve(J, self._cholesky(regul))
         else:
             raise NotImplementedError
 
-        return FMatDense(
+        return PFMapDense(
             layer_collection=self.layer_collection,
             generator=self.generator,
-            data=solution.view(s[0], s[1], sK[2], sK[3]),
+            data=solution.view(s[0], s[1], sJ[-1]),
         )

--- a/nngeometry/object/map.py
+++ b/nngeometry/object/map.py
@@ -20,7 +20,7 @@ class PFMap(ABC):
             return NotImplemented
 
     def __rmatmul__(self, other):
-        if hasattr(self, "adjoint"):
+        if isinstance(self, AdjointMixin):
             return self.adjoint() @ other
         else:
             return NotImplemented

--- a/nngeometry/object/map.py
+++ b/nngeometry/object/map.py
@@ -20,7 +20,10 @@ class PFMap(ABC):
             return NotImplemented
 
     def __rmatmul__(self, other):
-        return self.adjoint() @ other
+        if hasattr(self, "adjoint"):
+            return self.adjoint() @ other
+        else:
+            return NotImplemented
 
     @abstractmethod
     def jvp(self, v):

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -92,8 +92,6 @@ class PMatAbstract(ABC):
             return self.mv(other)
         elif isinstance(other, PFMapAdjoint):
             return self.mmap(other.adjoint()).adjoint()
-        elif isinstance(other, PMatAbstract):
-            return self.mm(other)
         else:
             return NotImplemented
 
@@ -102,8 +100,6 @@ class PMatAbstract(ABC):
             return self.mv(other)
         elif isinstance(other, PFMap):
             return self.mmap(other)
-        elif isinstance(other, PMatAbstract):
-            return other.mm(self)
         else:
             return NotImplemented
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -92,6 +92,8 @@ class PMatAbstract(ABC):
             return self.mv(other)
         elif isinstance(other, PFMapAdjoint):
             return self.mmap(other.adjoint()).adjoint()
+        elif isinstance(other, type(self)):
+            return self.mm(other)
         else:
             return NotImplemented
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -14,7 +14,7 @@ from nngeometry.layercollection import (
     LinearLayer,
 )
 from nngeometry.maths import kronecker
-from nngeometry.object.map import PFMap, PFMapDense
+from nngeometry.object.map import PFMap, PFMapAdjoint, PFMapDense
 from nngeometry.object.vector import PVector
 from nngeometry.solve import cg
 
@@ -87,13 +87,25 @@ class PMatAbstract(ABC):
             layer_collection=pfmap.layer_collection,
         )
 
-    def __matmul__(self, x):
-        if isinstance(x, PVector):
-            return self.mv(x)
-        elif isinstance(x, PFMap):
-            return self.mmap(x)
+    def __matmul__(self, other):
+        if isinstance(other, PVector):
+            return self.mv(other)
+        elif isinstance(other, PFMapAdjoint):
+            return self.mmap(other.adjoint()).adjoint()
+        elif isinstance(other, PMatAbstract):
+            return self.mm(other)
         else:
-            raise NotImplementedError("`x` should be an instance of PVector or PFMap")
+            return NotImplemented
+
+    def __rmatmul__(self, other):
+        if isinstance(other, PVector):
+            return self.mv(other)
+        elif isinstance(other, PFMap):
+            return self.mmap(other)
+        elif isinstance(other, PMatAbstract):
+            return other.mm(self)
+        else:
+            return NotImplemented
 
     @abstractmethod
     def get_device(self):

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -97,14 +97,6 @@ class PMatAbstract(ABC):
         else:
             return NotImplemented
 
-    def __rmatmul__(self, other):
-        if isinstance(other, PVector):
-            return self.mv(other)
-        elif isinstance(other, PFMap):
-            return self.mmap(other)
-        else:
-            return NotImplemented
-
     @abstractmethod
     def get_device(self):
         raise NotImplementedError

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -92,8 +92,6 @@ class PMatAbstract(ABC):
             return self.mv(other)
         elif isinstance(other, PFMapAdjoint):
             return self.mmap(other.adjoint()).adjoint()
-        elif isinstance(other, type(self)):
-            return self.mm(other)
         else:
             return NotImplemented
 

--- a/nngeometry/object/vector.py
+++ b/nngeometry/object/vector.py
@@ -409,10 +409,7 @@ class FVector:
         self.vector_repr = vector_repr
 
     def to_torch(self):
-        if self.vector_repr is not None:
-            return self.vector_repr
-        else:
-            return NotImplementedError
+        return self.vector_repr
 
     def dot(self, other):
         return torch.dot(self.to_torch().view(-1), other.to_torch().view(-1))

--- a/nngeometry/object/vector.py
+++ b/nngeometry/object/vector.py
@@ -414,9 +414,6 @@ class FVector:
         else:
             return NotImplementedError
 
-    def size(self, *args):
-        return self.vector_repr.size(*args)
-
     def dot(self, other):
         return torch.dot(self.to_torch().view(-1), other.to_torch().view(-1))
 

--- a/nngeometry/object/vector.py
+++ b/nngeometry/object/vector.py
@@ -413,3 +413,15 @@ class FVector:
             return self.vector_repr
         else:
             return NotImplementedError
+
+    def size(self, *args):
+        return self.vector_repr.size(*args)
+
+    def dot(self, other):
+        return torch.dot(self.to_torch().view(-1), other.to_torch().view(-1))
+
+    def __matmul__(self, other):
+        if isinstance(other, FVector):
+            return self.dot(other)
+        else:
+            return NotImplemented

--- a/nngeometry/object/vector.py
+++ b/nngeometry/object/vector.py
@@ -411,11 +411,11 @@ class FVector:
     def to_torch(self):
         return self.vector_repr
 
-    def dot(self, other):
-        return torch.dot(self.to_torch().view(-1), other.to_torch().view(-1))
+    def __add__(self, other):
+        return FVector(self.vector_repr + other.vector_repr)
 
-    def __matmul__(self, other):
-        if isinstance(other, FVector):
-            return self.dot(other)
-        else:
-            return NotImplemented
+    def __sub__(self, other):
+        return FVector(self.vector_repr - other.vector_repr)
+
+    def __rmul__(self, other):
+        return FVector(other * self.vector_repr)

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -42,19 +42,29 @@ def test_gram_vs_jacobian():
 
         check_ratio(gram.norm(), torch.linalg.norm(gram.to_torch()))
 
-        # __matmul__ API
+        # __op__
         torch.testing.assert_close((gram @ gram).to_torch(), (gram**2).to_torch())
         torch.testing.assert_close((gram + gram).to_torch(), (2 * gram).to_torch())
         torch.testing.assert_close((gram - gram + gram).to_torch(), gram.to_torch())
-        torch.testing.assert_close(
-            (gram.solve(gram, 1e-3)).to_torch(), (gram.inv(1e-3) @ gram).to_torch()
-        )
         with pytest.raises(TypeError):
             gram @ 2
         with pytest.raises(TypeError):
             2 @ gram
 
+        # solve
         df1 = random_fvector(jacobian.size(1), jacobian.size(0))
+        torch.testing.assert_close(
+            (gram.solve(gram, 1e-3)).to_torch(), (gram.inv(1e-3) @ gram).to_torch()
+        )
+        torch.testing.assert_close(
+            (gram.solve(df1, 1e-3)).to_torch(), (gram.inv(1e-3) @ df1).to_torch()
+        )
+        with pytest.raises(NotImplementedError):
+            gram.solve(gram, solve="prout")
+        with pytest.raises(NotImplementedError):
+            gram.solve(df1, solve="prout")
+
+        # non symetric
         df2 = random_fvector(25, 10)
         asym_gram = FMatDense(
             lc, gram.generator, data=torch.rand(gram.size(0), gram.size(1), 25, 10)

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -49,10 +49,13 @@ def test_gram_vs_jacobian():
         torch.testing.assert_close(
             (gram.solve(gram, 1e-3)).to_torch(), (gram.inv(1e-3) @ gram).to_torch()
         )
+        with pytest.raises(TypeError):
+            gram @ 2
+        with pytest.raises(TypeError):
+            2 @ gram
 
-        df = random_fvector(jacobian.size(1), jacobian.size(0))
-        torch.testing.assert_close((gram @ df).to_torch(), (df @ gram).to_torch())
-
+        df1 = random_fvector(jacobian.size(1), jacobian.size(0))
+        df2 = random_fvector(25, 10)
         asym_gram = FMatDense(
             lc, gram.generator, data=torch.rand(gram.size(0), gram.size(1), 25, 10)
         )
@@ -60,8 +63,25 @@ def test_gram_vs_jacobian():
             (gram @ asym_gram).adjoint().to_torch(),
             (asym_gram.adjoint() @ gram).to_torch(),
         )
+        torch.testing.assert_close(
+            (asym_gram @ df2).to_torch(), (df2 @ asym_gram.adjoint()).to_torch()
+        )
+        torch.testing.assert_close(
+            (asym_gram.adjoint() @ df1).to_torch(), (df1 @ asym_gram).to_torch()
+        )
 
-        with pytest.raises(TypeError):
-            gram @ 2
-        with pytest.raises(TypeError):
-            2 @ gram
+        # unsupported operations on asymetric gram matrices
+        with pytest.raises(RuntimeError):
+            df2 @ asym_gram
+        with pytest.raises(RuntimeError):
+            asym_gram @ df1
+        with pytest.raises(RuntimeError):
+            asym_gram.vTMv(df1)
+        with pytest.raises(RuntimeError):
+            asym_gram.mTMm(asym_gram)
+        with pytest.raises(RuntimeError):
+            asym_gram.compute_eigendecomposition(impl="eigh")
+        with pytest.raises(RuntimeError):
+            asym_gram.inv()
+        with pytest.raises(RuntimeError):
+            asym_gram.solve(df2, solve="default")

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -44,6 +44,10 @@ def test_gram_vs_jacobian():
 
         # __op__
         torch.testing.assert_close((gram @ gram).to_torch(), (gram**2).to_torch())
+        torch.testing.assert_close(
+            (gram @ jacobian @ jacobian.adjoint()).to_torch(),
+            (gram @ (jacobian @ jacobian.adjoint())).to_torch(),
+        )
         torch.testing.assert_close((gram + gram).to_torch(), (2 * gram).to_torch())
         torch.testing.assert_close((gram - gram + gram).to_torch(), gram.to_torch())
         with pytest.raises(TypeError):

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -5,7 +5,7 @@ from tasks import (
     get_conv_task,
     get_fullyconnect_task,
 )
-from utils import check_ratio, check_tensors
+from utils import check_ratio
 
 from nngeometry import GramMatrix, Jacobian
 from nngeometry.object.fspace import FMatDense
@@ -82,6 +82,9 @@ def test_gram_vs_jacobian():
         )
         torch.testing.assert_close(
             (asym_gram.adjoint() @ df1).to_torch(), (df1 @ asym_gram).to_torch()
+        )
+        torch.testing.assert_close(
+            asym_gram.adjoint().adjoint().to_torch(), asym_gram.to_torch()
         )
 
         # unsupported operations on asymetric gram matrices

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from tasks import (
     get_conv_gn_task,
@@ -7,6 +8,9 @@ from tasks import (
 from utils import check_ratio, check_tensors
 
 from nngeometry import GramMatrix, Jacobian
+from nngeometry.object.fspace import FMatDense
+from nngeometry.object.map import PFMapDense
+from nngeometry.object.vector import random_fvector
 
 nonlinear_tasks = [get_conv_gn_task, get_fullyconnect_task, get_conv_task]
 
@@ -15,19 +19,49 @@ def test_gram_vs_jacobian():
     for get_task in nonlinear_tasks:
         loader, lc, parameters, model, function = get_task()
 
-        gram = GramMatrix(model=model, function=function, loader=loader)
-        jacobian = Jacobian(model=model, function=function, loader=loader)
-
-        jacobian_torch = jacobian.to_torch()
-        sj = jacobian_torch.size()
-        gram_computed = torch.mm(
-            jacobian_torch.view(-1, sj[2]), jacobian_torch.view(-1, sj[2]).t()
+        jacobian = Jacobian(
+            model=model,
+            function=function,
+            loader=loader,
+            layer_collection=lc,
+            representation=PFMapDense,
+        )
+        gram = GramMatrix(
+            model=model,
+            function=function,
+            loader=loader,
+            layer_collection=lc,
+            representation=FMatDense,
         )
 
-        check_tensors(
-            gram_computed.view(sj[0], sj[1], sj[0], sj[1]),
-            gram.to_torch(),
-            eps=1e-4,
+        torch.testing.assert_close(
+            gram.to_torch(), (jacobian @ jacobian.adjoint()).to_torch()
+        )
+        assert gram.size(0) == gram.size(2)
+        assert gram.size(1) == gram.size(3)
+
+        check_ratio(gram.norm(), torch.linalg.norm(gram.to_torch()))
+
+        # __matmul__ API
+        torch.testing.assert_close((gram @ gram).to_torch(), (gram**2).to_torch())
+        torch.testing.assert_close((gram + gram).to_torch(), (2 * gram).to_torch())
+        torch.testing.assert_close((gram - gram + gram).to_torch(), gram.to_torch())
+        torch.testing.assert_close(
+            (gram.solve(gram, 1e-3)).to_torch(), (gram.inv(1e-3) @ gram).to_torch()
         )
 
-        check_ratio(gram.norm(), torch.linalg.norm(gram_computed))
+        df = random_fvector(jacobian.size(1), jacobian.size(0))
+        torch.testing.assert_close((gram @ df).to_torch(), (df @ gram).to_torch())
+
+        asym_gram = FMatDense(
+            lc, gram.generator, data=torch.rand(gram.size(0), gram.size(1), 25, 10)
+        )
+        torch.testing.assert_close(
+            (gram @ asym_gram).adjoint().to_torch(),
+            (asym_gram.adjoint() @ gram).to_torch(),
+        )
+
+        with pytest.raises(TypeError):
+            gram @ 2
+        with pytest.raises(TypeError):
+            2 @ gram

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -9,7 +9,7 @@ from utils import check_ratio
 
 from nngeometry import GramMatrix, Jacobian
 from nngeometry.object.fspace import FMatDense
-from nngeometry.object.map import PFMapDense
+from nngeometry.object.map import PFMapDense, random_pfmap
 from nngeometry.object.vector import random_fvector
 
 nonlinear_tasks = [get_conv_gn_task, get_fullyconnect_task, get_conv_task]
@@ -43,11 +43,6 @@ def test_gram_vs_jacobian():
         check_ratio(gram.norm(), torch.linalg.norm(gram.to_torch()))
 
         # __op__
-        torch.testing.assert_close((gram @ gram).to_torch(), (gram**2).to_torch())
-        torch.testing.assert_close(
-            (gram @ jacobian @ jacobian.adjoint()).to_torch(),
-            (gram @ (jacobian @ jacobian.adjoint())).to_torch(),
-        )
         torch.testing.assert_close((gram + gram).to_torch(), (2 * gram).to_torch())
         torch.testing.assert_close((gram - gram + gram).to_torch(), gram.to_torch())
         with pytest.raises(TypeError):
@@ -57,28 +52,15 @@ def test_gram_vs_jacobian():
 
         # solve
         df1 = random_fvector(jacobian.size(1), jacobian.size(0))
-        torch.testing.assert_close(
-            (gram.solve(gram, 1e-3)).to_torch(), (gram.inv(1e-3) @ gram).to_torch()
-        )
+        J = random_pfmap(lc, (jacobian.size(1), jacobian.size(0)))
         torch.testing.assert_close(
             (gram.solve(df1, 1e-3)).to_torch(), (gram.inv(1e-3) @ df1).to_torch()
+        )
+        torch.testing.assert_close(
+            (gram.solve(J, 1e-3)).to_torch(), (gram.inv(1e-3) @ J).to_torch()
         )
         with pytest.raises(NotImplementedError):
             gram.solve(gram, solve="prout")
         with pytest.raises(NotImplementedError):
             gram.solve(df1, solve="prout")
 
-        # non symetric
-        df2 = random_fvector(25, 10)
-        asym_gram = FMatDense(
-            lc, gram.generator, data=torch.rand(gram.size(0), gram.size(1), 25, 10)
-        )
-        # unsupported operations on asymetric gram matrices
-        with pytest.raises(RuntimeError):
-            asym_gram @ df1
-        with pytest.raises(RuntimeError):
-            asym_gram.compute_eigendecomposition(impl="eigh")
-        with pytest.raises(RuntimeError):
-            asym_gram.inv()
-        with pytest.raises(RuntimeError):
-            asym_gram.solve(df2, solve="default")

--- a/tests/test_gram.py
+++ b/tests/test_gram.py
@@ -73,29 +73,9 @@ def test_gram_vs_jacobian():
         asym_gram = FMatDense(
             lc, gram.generator, data=torch.rand(gram.size(0), gram.size(1), 25, 10)
         )
-        torch.testing.assert_close(
-            (gram @ asym_gram).adjoint().to_torch(),
-            (asym_gram.adjoint() @ gram).to_torch(),
-        )
-        torch.testing.assert_close(
-            (asym_gram @ df2).to_torch(), (df2 @ asym_gram.adjoint()).to_torch()
-        )
-        torch.testing.assert_close(
-            (asym_gram.adjoint() @ df1).to_torch(), (df1 @ asym_gram).to_torch()
-        )
-        torch.testing.assert_close(
-            asym_gram.adjoint().adjoint().to_torch(), asym_gram.to_torch()
-        )
-
         # unsupported operations on asymetric gram matrices
         with pytest.raises(RuntimeError):
-            df2 @ asym_gram
-        with pytest.raises(RuntimeError):
             asym_gram @ df1
-        with pytest.raises(RuntimeError):
-            asym_gram.vTMv(df1)
-        with pytest.raises(RuntimeError):
-            asym_gram.mTMm(asym_gram)
         with pytest.raises(RuntimeError):
             asym_gram.compute_eigendecomposition(impl="eigh")
         with pytest.raises(RuntimeError):

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -3,8 +3,10 @@ import torch
 from tasks import get_conv_gn_task, get_conv_task, get_fullyconnect_task
 
 from nngeometry import Jacobian
-from nngeometry.backend import TorchHooksJacobianBackend
+from nngeometry.gram import GramMatrix
+from nngeometry.metrics import GradientSecondMoment
 from nngeometry.object.fspace import FMatDense
+from nngeometry.object.map import PFMapDense
 from nngeometry.object.pspace import PMatDense
 from nngeometry.object.vector import random_fvector, random_pvector
 
@@ -14,26 +16,37 @@ nonlinear_tasks = [get_conv_gn_task, get_fullyconnect_task, get_conv_task]
 def test_jacobian():
     for get_task in nonlinear_tasks:
         loader, lc, parameters, model, function = get_task()
-        backend = TorchHooksJacobianBackend(
-            model=model,
-            function=function,
-        )
-
-        FMat_dense = FMatDense(generator=backend, examples=loader, layer_collection=lc)
-        PMat_dense = PMatDense(generator=backend, examples=loader, layer_collection=lc)
 
         jacobian = Jacobian(
-            model=model, function=function, loader=loader, layer_collection=lc
+            model=model,
+            function=function,
+            loader=loader,
+            layer_collection=lc,
+            representation=PFMapDense,
+        )
+        gram = GramMatrix(
+            model=model,
+            function=function,
+            loader=loader,
+            layer_collection=lc,
+            representation=FMatDense,
+        )
+        fim = GradientSecondMoment(
+            model=model,
+            function=function,
+            loader=loader,
+            layer_collection=lc,
+            representation=PMatDense,
         )
 
         dw = random_pvector(layer_collection=lc)
         df = random_fvector(n_samples=jacobian.size(1), n_output=jacobian.size(0))
 
         torch.testing.assert_close(
-            FMat_dense.to_torch(), (jacobian @ jacobian.adjoint()).to_torch()
+            gram.to_torch(), (jacobian @ jacobian.adjoint()).to_torch()
         )
         torch.testing.assert_close(
-            PMat_dense.to_torch(),
+            fim.to_torch(),
             (1 / jacobian.size(1) * (jacobian.adjoint() @ jacobian)).to_torch(),
         )
         torch.testing.assert_close(

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -51,6 +51,7 @@ def test_dense():
         generator2 = TorchHooksJacobianBackend(model=model2, function=function1)
         M_dense1 = PMatDense(generator=generator1, examples=loader, layer_collection=lc)
         M_dense2 = PMatDense(generator=generator2, examples=loader, layer_collection=lc)
+        M_diag = PMatDiag(generator=generator1, examples=loader, layer_collection=lc)
 
         # mm between 2 PMapDense
         prod = M_dense1.mm(M_dense2)
@@ -84,6 +85,15 @@ def test_dense():
             torch.mv(M_dense1_tensor, v.to_torch()), (M_dense1 @ v).to_torch()
         )
         torch.testing.assert_close((M_dense1 @ v).to_torch(), (v @ M_dense1).to_torch())
+
+        ## matmul with pmat
+        torch.testing.assert_close(
+            M_dense1_tensor @ M_dense1_tensor,
+            (M_dense1 @ M_dense1).to_torch(),
+        )
+
+        with pytest.raises(TypeError):
+            M_dense1 @ M_diag
 
 
 def test_blockdiag():

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -1,11 +1,10 @@
 import pytest
 import torch
-from nngeometry.object.map import PFMapDense
 from tasks import get_conv_gn_task, get_conv_task, get_fullyconnect_task
 from utils import check_tensors
 
 from nngeometry.backend import TorchHooksJacobianBackend
-from nngeometry.object.map import random_pfmap
+from nngeometry.object.map import PFMapDense, random_pfmap
 from nngeometry.object.pspace import PMatBlockDiag, PMatDense, PMatDiag
 from nngeometry.object.vector import random_pvector
 
@@ -69,13 +68,17 @@ def test_dense():
             torch.mm(pfmap.to_torch().view(3 * 4, -1), M_dense1_tensor).view(3, 4, -1),
             (M_dense1 @ pfmap.adjoint()).adjoint().to_torch(),
         )
+        torch.testing.assert_close(
+            (M_dense1 @ pfmap.adjoint()).adjoint().to_torch(),
+            (pfmap @ M_dense1).to_torch(),
+        )
 
         ## matmul with pvector
         v = random_pvector(layer_collection=lc)
         torch.testing.assert_close(
-            torch.mv(M_dense1_tensor, v.to_torch()),
-            (M_dense1 @ v).to_torch(),
+            torch.mv(M_dense1_tensor, v.to_torch()), (M_dense1 @ v).to_torch()
         )
+        torch.testing.assert_close((M_dense1 @ v).to_torch(), (v @ M_dense1).to_torch())
 
 
 def test_blockdiag():

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -67,7 +67,7 @@ def test_dense():
         pfmap = random_pfmap(layer_collection=lc, output_size=(3, 4))
         torch.testing.assert_close(
             torch.mm(pfmap.to_torch().view(3 * 4, -1), M_dense1_tensor).view(3, 4, -1),
-            (M_dense1 @ pfmap).to_torch(),
+            (M_dense1 @ pfmap.adjoint()).adjoint().to_torch(),
         )
 
         ## matmul with pvector

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -73,6 +73,11 @@ def test_dense():
             (pfmap @ M_dense1).to_torch(),
         )
 
+        with pytest.raises(TypeError):
+            M_dense1 @ pfmap
+        with pytest.raises(TypeError):
+            pfmap.adjoint() @ M_dense1
+
         ## matmul with pvector
         v = random_pvector(layer_collection=lc)
         torch.testing.assert_close(

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -69,13 +69,12 @@ def test_dense():
             torch.mm(pfmap.to_torch().view(3 * 4, -1), M_dense1_tensor).view(3, 4, -1),
             (M_dense1 @ pfmap.adjoint()).adjoint().to_torch(),
         )
-        torch.testing.assert_close(
-            (M_dense1 @ pfmap.adjoint()).adjoint().to_torch(),
-            (pfmap @ M_dense1).to_torch(),
-        )
 
+        M_dense1 @ pfmap.adjoint()
         with pytest.raises(TypeError):
             M_dense1 @ pfmap
+        with pytest.raises(TypeError):
+            pfmap @ M_dense1
         with pytest.raises(TypeError):
             pfmap.adjoint() @ M_dense1
 
@@ -84,7 +83,6 @@ def test_dense():
         torch.testing.assert_close(
             torch.mv(M_dense1_tensor, v.to_torch()), (M_dense1 @ v).to_torch()
         )
-        torch.testing.assert_close((M_dense1 @ v).to_torch(), (v @ M_dense1).to_torch())
 
         ## matmul with pmat
         torch.testing.assert_close(

--- a/tests/test_representations.py
+++ b/tests/test_representations.py
@@ -51,7 +51,6 @@ def test_dense():
         generator2 = TorchHooksJacobianBackend(model=model2, function=function1)
         M_dense1 = PMatDense(generator=generator1, examples=loader, layer_collection=lc)
         M_dense2 = PMatDense(generator=generator2, examples=loader, layer_collection=lc)
-        M_diag = PMatDiag(generator=generator1, examples=loader, layer_collection=lc)
 
         # mm between 2 PMapDense
         prod = M_dense1.mm(M_dense2)
@@ -83,15 +82,6 @@ def test_dense():
         torch.testing.assert_close(
             torch.mv(M_dense1_tensor, v.to_torch()), (M_dense1 @ v).to_torch()
         )
-
-        ## matmul with pmat
-        torch.testing.assert_close(
-            M_dense1_tensor @ M_dense1_tensor,
-            (M_dense1 @ M_dense1).to_torch(),
-        )
-
-        with pytest.raises(TypeError):
-            M_dense1 @ M_diag
 
 
 def test_blockdiag():

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -1,3 +1,5 @@
+import gc
+import time
 from functools import partial
 
 import pytest
@@ -266,6 +268,25 @@ def test_jacobian_fdense_vs_pullback():
 
             with pytest.raises(RuntimeError):
                 FMat_dense.norm("prout")
+
+            start_time_1 = time.perf_counter()
+            FMat_dense.solve(df, regul=1)
+            end_time_1 = time.perf_counter()
+            solve_time_init = end_time_1 - start_time_1
+
+            start_time_2 = time.perf_counter()
+            FMat_dense.solve(df, regul=1)
+            end_time_2 = time.perf_counter()
+            solve_time_cached = end_time_2 - start_time_2
+
+            assert solve_time_cached < solve_time_init
+
+            check = []
+            FMatDense.__del__ = lambda self: check.append("deleted")
+            FMat_dense = None
+            gc.collect()
+
+            assert len(check) > 0
 
 
 def test_jacobian_eigendecomposition_fdense():

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -257,6 +257,13 @@ def test_jacobian_fdense_vs_pullback():
             frob_direct = (FMat_dense.to_torch() ** 2).sum() ** 0.5
             check_ratio(frob_direct, frob_FMat)
 
+            # Test trace
+            trace_FMat = FMat_dense.trace()
+            FMat_dense.compute_eigendecomposition()
+            evals, evecs = FMat_dense.get_eigendecomposition()
+            trace_eigh = evals.sum()
+            check_ratio(trace_FMat, trace_eigh)
+
             with pytest.raises(RuntimeError):
                 FMat_dense.norm("prout")
 

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -1,5 +1,3 @@
-import gc
-import time
 from functools import partial
 
 import pytest
@@ -268,25 +266,6 @@ def test_jacobian_fdense_vs_pullback():
 
             with pytest.raises(RuntimeError):
                 FMat_dense.norm("prout")
-
-            start_time_1 = time.perf_counter()
-            FMat_dense.solve(df, regul=1)
-            end_time_1 = time.perf_counter()
-            solve_time_init = end_time_1 - start_time_1
-
-            start_time_2 = time.perf_counter()
-            FMat_dense.solve(df, regul=1)
-            end_time_2 = time.perf_counter()
-            solve_time_cached = end_time_2 - start_time_2
-
-            assert solve_time_cached < solve_time_init
-
-            check = []
-            FMatDense.__del__ = lambda self: check.append("deleted")
-            FMat_dense = None
-            gc.collect()
-
-            assert len(check) > 0
 
 
 def test_jacobian_eigendecomposition_fdense():

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -232,7 +232,16 @@ def test_jacobian_fdense_vs_pullback():
             )
 
             n_output = FMat_dense.to_torch().size(0)
+
+            # Test mv
             df = random_fvector(len(loader.sampler), n_output, device=device)
+            Mv_PMat = FMat_dense.mv(df)
+            vjp = pull_back.vjp(df)
+            Mv_pf_pb = pull_back.jvp(vjp)
+            check_tensors(
+                Mv_pf_pb.to_torch(),
+                Mv_PMat.to_torch(),
+            )
 
             # Test to_torch to get dense tensor
             jacobian = pull_back.to_torch()
@@ -246,16 +255,27 @@ def test_jacobian_fdense_vs_pullback():
                 eps=1e-4,
             )
 
-            # Test vTMv
-            vTMv_FMat = FMat_dense.vTMv(df)
-            Jv_pullback = pull_back.vjp(df).to_torch()
-            vTMv_pullforward = torch.dot(Jv_pullback, Jv_pullback)
-            check_ratio(vTMv_pullforward, vTMv_FMat)
+
+def test_jacobian_fdense():
+    for get_task in linear_tasks + nonlinear_tasks:
+        for centering in [True, False]:
+            loader, lc, parameters, model, function = get_task()
+            generator = TorchHooksJacobianBackend(
+                model=model,
+                function=function,
+                centering=centering,
+            )
+            FMat_dense = FMatDense(
+                generator=generator, examples=loader, layer_collection=lc
+            )
 
             # Test frobenius
             frob_FMat = FMat_dense.norm()
             frob_direct = (FMat_dense.to_torch() ** 2).sum() ** 0.5
             check_ratio(frob_direct, frob_FMat)
+
+            with pytest.raises(RuntimeError):
+                FMat_dense.norm("prout")
 
             # Test trace
             trace_FMat = FMat_dense.trace()
@@ -264,8 +284,17 @@ def test_jacobian_fdense_vs_pullback():
             trace_eigh = evals.sum()
             check_ratio(trace_FMat, trace_eigh)
 
-            with pytest.raises(RuntimeError):
-                FMat_dense.norm("prout")
+            n_examples = len(loader.sampler)
+            n_output = FMat_dense.to_torch().size(0)
+            df = random_fvector(n_examples, n_output, device=device)
+
+            # Test inv
+            regul = 1e-3
+            FMat_inv = FMat_dense.inv(regul=regul)
+            torch.testing.assert_close(
+                df.to_torch(),
+                FMat_inv.mv(FMat_dense.mv(df) + n_examples * regul * df).to_torch(),
+            )
 
 
 def test_jacobian_eigendecomposition_fdense():


### PR DESCRIPTION
I did an API a little bit different of PFMap for adjoint of FMat. Because the most general case if having it in FMatAbstract as a noop (because most of FMats are going to be Gram matrices, thus square and symetric, and FMatDense has a specialized method (that do a transpose) to deal with FMatDense that represents NTK between test and training points (non square).

Using methods that requires symetric matrices (such as solve/inv) returns a RuntimeError when used on non symetric matrices.

I also added most of methods that are useful on fmatdense in this PR.

For solve i used cholesky decomposition, but could be swapped for LDL or LU.

We could introduce a solve with QR/SVD and a pinv to work for non square FMatDense but i don't know if its truly useful.