### PR TITLE
Reduce number of backward passes for implict_mv in torch hooks backend

### DIFF
--- a/nngeometry/backend/torch_hooks/grads.py
+++ b/nngeometry/backend/torch_hooks/grads.py
@@ -618,6 +618,12 @@ class EmbeddingJacobianFactory(JacobianFactory):
         left_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(dim=0))
         right_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(dim=0))
 
+    @classmethod
+    def Jv(cls, buffer, mod, layer, x, gy, v, v_bias):
+        bs = x.size(0)
+        gy2 = F.embedding(x, v)
+        buffer.add_((gy * gy2).view(bs, -1).sum(dim=1))
+
 
 FactoryMap = {
     LinearLayer: LinearJacobianFactory,

--- a/nngeometry/backend/torch_hooks/torch_hooks.py
+++ b/nngeometry/backend/torch_hooks/torch_hooks.py
@@ -659,6 +659,7 @@ class TorchHooksJacobianBackend(AbstractBackend):
 
             f_output = self.function(*d).view(bs, -1)
             n_output = f_output.size(-1)
+            pseudo_loss = 0
             for i in range(n_output):
                 # TODO reuse instead of reallocating memory
                 self._buffer["Jv"] = torch.zeros((1, bs), device=device, dtype=dtype)
@@ -670,16 +671,17 @@ class TorchHooksJacobianBackend(AbstractBackend):
                     retain_graph=True,
                     only_inputs=True,
                 )
-                self._buffer["compute_switch"] = False
-                pseudo_loss = torch.dot(self._buffer["Jv"][0, :], f_output[:, i])
-                grads = torch.autograd.grad(
-                    pseudo_loss,
-                    parameters,
-                    retain_graph=i < n_output - 1,
-                    only_inputs=True,
-                )
-                for i_p, p in enumerate(parameters):
-                    output[p].add_(grads[i_p])
+                pseudo_loss += torch.dot(self._buffer["Jv"][0, :], f_output[:, i])
+
+            self._buffer["compute_switch"] = False
+            grads = torch.autograd.grad(
+                pseudo_loss,
+                parameters,
+                retain_graph=False,
+                only_inputs=True,
+            )
+            for i_p, p in enumerate(parameters):
+                output[p].add_(grads[i_p])
 
         output_dict = dict()
         for layer_id, layer in layer_collection.layers.items():


### PR DESCRIPTION
Reduce the total number of reverse passes when n_outputs > 1 (seems to be close to x2 improvement on a resnet18 on cifar10 with a 3090).

I also added a specialized method for Embedding Layers