### PR TITLE
Matmul reordering in kpsvd

### DIFF
--- a/nngeometry/backend/torch_hooks/grads.py
+++ b/nngeometry/backend/torch_hooks/grads.py
@@ -649,9 +649,6 @@ class EmbeddingJacobianFactory(JacobianFactory):
         os = gy.size(-1)
         A = F.one_hot(x.view(bs, -1), num_classes=layer.num_embeddings).to(gy.dtype)
 
-        if hasattr(layer, "has_bias") and layer.has_bias():
-            A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
-
         S = gy.view(bs, -1, os)
 
         R, L = _compute_kpsvd_blocks(A, S)

--- a/nngeometry/backend/torch_hooks/grads.py
+++ b/nngeometry/backend/torch_hooks/grads.py
@@ -21,19 +21,21 @@ from nngeometry.layercollection import (
 from .grads_conv import conv1d_backward, conv2d_backward, convtranspose2d_backward
 
 
-def _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S):
-    spatial_locations, ps = A.size(1), A.size(2)
-    os = S.size(2)
+def _compute_kpsvd_blocks(A, S):
+    spatial_locations, ps, os = A.size(1), A.size(2), S.size(2)
 
+    # GGt = StAAtS, GtG = AtSStA
     if spatial_locations**2 <= ps * os:
         SSt = torch.bmm(S, S.transpose(1, 2))
-        right_buffer.add_(torch.bmm(A.transpose(1, 2), torch.bmm(SSt, A)).sum(0))
+        right_block = torch.bmm(A.transpose(1, 2), torch.bmm(SSt, A)).sum(0)
         AAt = torch.bmm(A, A.transpose(1, 2))
-        left_buffer.add_(torch.bmm(S.transpose(1, 2), torch.bmm(AAt, S)).sum(0))
+        left_block = torch.bmm(S.transpose(1, 2), torch.bmm(AAt, S)).sum(0)
     else:
         G = torch.bmm(S.transpose(1, 2), A)
-        right_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(0))
-        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(0))
+        right_block = torch.bmm(G.transpose(1, 2), G).sum(0)
+        left_block = torch.bmm(G, G.transpose(1, 2)).sum(0)
+
+    return right_block, left_block
 
 
 class JacobianFactory:
@@ -188,7 +190,9 @@ class LinearJacobianFactory(JacobianFactory):
         if layer.has_bias():
             A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
 
-        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
+        R, L = _compute_kpsvd_blocks(A, S)
+        right_buffer.add_(R)
+        left_buffer.add_(L)
 
     @classmethod
     def quasidiag(cls, buffer_diag, buffer_cross, mod, layer, x, gy):
@@ -292,7 +296,10 @@ class Conv2dJacobianFactory(JacobianFactory):
             A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
 
         S = gy.flatten(2).transpose(1, 2)
-        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
+
+        R, L = _compute_kpsvd_blocks(A, S)
+        right_buffer.add_(R)
+        left_buffer.add_(L)
 
     @classmethod
     def quasidiag(cls, buffer_diag, buffer_cross, mod, layer, x, gy):
@@ -572,7 +579,9 @@ class Conv1dJacobianFactory(JacobianFactory):
 
         S = gy.flatten(2).transpose(1, 2)
 
-        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
+        R, L = _compute_kpsvd_blocks(A, S)
+        right_buffer.add_(R)
+        left_buffer.add_(L)
 
 
 def check_embedding_arguments(mod):
@@ -645,7 +654,9 @@ class EmbeddingJacobianFactory(JacobianFactory):
 
         S = gy.view(bs, -1, os)
 
-        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
+        R, L = _compute_kpsvd_blocks(A, S)
+        right_buffer.add_(R)
+        left_buffer.add_(L)
 
 
 FactoryMap = {

--- a/nngeometry/backend/torch_hooks/grads.py
+++ b/nngeometry/backend/torch_hooks/grads.py
@@ -21,19 +21,19 @@ from nngeometry.layercollection import (
 from .grads_conv import conv1d_backward, conv2d_backward, convtranspose2d_backward
 
 
-def _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S):
+def _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S):
     spatial_locations, ps = A.size(1), A.size(2)
     os = S.size(2)
 
     if spatial_locations**2 <= ps * os:
-        AAt = torch.bmm(A, A.transpose(1, 2))
-        left_buffer.add_(torch.bmm(S.transpose(1, 2), torch.bmm(AAt, S)).sum(0))
         SSt = torch.bmm(S, S.transpose(1, 2))
         right_buffer.add_(torch.bmm(A.transpose(1, 2), torch.bmm(SSt, A)).sum(0))
+        AAt = torch.bmm(A, A.transpose(1, 2))
+        left_buffer.add_(torch.bmm(S.transpose(1, 2), torch.bmm(AAt, S)).sum(0))
     else:
         G = torch.bmm(S.transpose(1, 2), A)
-        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(0))
         right_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(0))
+        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(0))
 
 
 class JacobianFactory:
@@ -179,7 +179,7 @@ class LinearJacobianFactory(JacobianFactory):
             buffer.add_((per_ex_kfe_grad**2).sum(dim=0).view(-1))
 
     @classmethod
-    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
+    def one_iter_kpsvd_blocks(cls, right_buffer, left_buffer, mod, layer, x, gy):
         bs, xs = x.size(0), x.size(-1)
         os = gy.size(-1)
         A = x.view(bs, -1, xs)
@@ -188,7 +188,7 @@ class LinearJacobianFactory(JacobianFactory):
         if layer.has_bias():
             A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
 
-        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
+        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
 
     @classmethod
     def quasidiag(cls, buffer_diag, buffer_cross, mod, layer, x, gy):
@@ -279,7 +279,7 @@ class Conv2dJacobianFactory(JacobianFactory):
         buffer.add_((indiv_gw**2).sum(dim=0).view(-1))
 
     @classmethod
-    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
+    def one_iter_kpsvd_blocks(cls, right_buffer, left_buffer, mod, layer, x, gy):
         A = F.unfold(
             x,
             kernel_size=mod.kernel_size,
@@ -292,7 +292,7 @@ class Conv2dJacobianFactory(JacobianFactory):
             A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
 
         S = gy.flatten(2).transpose(1, 2)
-        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
+        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
 
     @classmethod
     def quasidiag(cls, buffer_diag, buffer_cross, mod, layer, x, gy):
@@ -558,7 +558,7 @@ class Conv1dJacobianFactory(JacobianFactory):
         buffer.add_((indiv_gw**2).sum(dim=0).view(-1))
 
     @classmethod
-    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
+    def one_iter_kpsvd_blocks(cls, right_buffer, left_buffer, mod, layer, x, gy):
         A = F.unfold(
             x.unsqueeze(2),
             kernel_size=(1, mod.kernel_size[0]),
@@ -572,7 +572,7 @@ class Conv1dJacobianFactory(JacobianFactory):
 
         S = gy.flatten(2).transpose(1, 2)
 
-        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
+        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
 
 
 def check_embedding_arguments(mod):
@@ -633,7 +633,7 @@ class EmbeddingJacobianFactory(JacobianFactory):
         buffer.add_((indiv_gw**2).sum(dim=0).view(-1))
 
     @classmethod
-    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
+    def one_iter_kpsvd_blocks(cls, right_buffer, left_buffer, mod, layer, x, gy):
         check_embedding_arguments(mod)
 
         bs = x.size(0)
@@ -645,7 +645,7 @@ class EmbeddingJacobianFactory(JacobianFactory):
 
         S = gy.view(bs, -1, os)
 
-        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
+        _acc_one_iter_kpsvd_blocks(right_buffer, left_buffer, A, S)
 
 
 FactoryMap = {

--- a/nngeometry/backend/torch_hooks/grads.py
+++ b/nngeometry/backend/torch_hooks/grads.py
@@ -21,6 +21,21 @@ from nngeometry.layercollection import (
 from .grads_conv import conv1d_backward, conv2d_backward, convtranspose2d_backward
 
 
+def _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S):
+    spatial_locations, ps = A.size(1), A.size(2)
+    os = S.size(2)
+
+    if spatial_locations**2 <= ps * os:
+        AAt = torch.bmm(A, A.transpose(1, 2))
+        left_buffer.add_(torch.bmm(S.transpose(1, 2), torch.bmm(AAt, S)).sum(0))
+        SSt = torch.bmm(S, S.transpose(1, 2))
+        right_buffer.add_(torch.bmm(A.transpose(1, 2), torch.bmm(SSt, A)).sum(0))
+    else:
+        G = torch.bmm(S.transpose(1, 2), A)
+        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(0))
+        right_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(0))
+
+
 class JacobianFactory:
     @classmethod
     def diag(cls, buffer, mod, layer, x, gy):
@@ -165,17 +180,15 @@ class LinearJacobianFactory(JacobianFactory):
 
     @classmethod
     def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
-        bs = x.size(0)
-        if gy.ndim == 2:
-            gy = gy[:, None, :]
-            x = x[:, None, :]
-        indiv_gw = torch.bmm(gy.transpose(1, 2), x)
-        G = indiv_gw.view(bs, mod.weight.size(0), -1)
+        bs, xs = x.size(0), x.size(-1)
+        os = gy.size(-1)
+        A = x.view(bs, -1, xs)
+        S = gy.view(bs, -1, os)
+
         if layer.has_bias():
-            indiv_gb = gy.transpose(1, 2)
-            G = torch.cat([G, indiv_gb], dim=2)
-        right_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(dim=0))
-        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(dim=0))
+            A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
+
+        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
 
     @classmethod
     def quasidiag(cls, buffer_diag, buffer_cross, mod, layer, x, gy):
@@ -195,17 +208,6 @@ class Conv2dJacobianFactory(JacobianFactory):
         buffer[:, :w_numel].add_(indiv_gw.view(bs, -1))
         if layer.has_bias():
             buffer[:, w_numel:].add_(gy.sum(dim=(2, 3)))
-
-    @classmethod
-    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
-        bs = x.size(0)
-        indiv_gw = conv2d_backward(mod, x, gy)
-        G = indiv_gw.view(bs, mod.weight.size(0), -1)
-        if layer.has_bias():
-            indiv_gb = gy.sum(dim=(2, 3)).unsqueeze(2)
-            G = torch.cat([G, indiv_gb], dim=2)
-        right_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(dim=0))
-        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(dim=0))
 
     @classmethod
     def Jv(cls, buffer, mod, layer, x, gy, v, v_bias):
@@ -275,6 +277,22 @@ class Conv2dJacobianFactory(JacobianFactory):
             gy_kfe.view(bs, gy_s[1], -1), x_kfe.view(bs, -1, x_kfe.size(1))
         )
         buffer.add_((indiv_gw**2).sum(dim=0).view(-1))
+
+    @classmethod
+    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
+        A = F.unfold(
+            x,
+            kernel_size=mod.kernel_size,
+            stride=mod.stride,
+            padding=mod.padding,
+            dilation=mod.dilation,
+        ).transpose(1, 2)
+
+        if layer.has_bias():
+            A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
+
+        S = gy.flatten(2).transpose(1, 2)
+        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
 
     @classmethod
     def quasidiag(cls, buffer_diag, buffer_cross, mod, layer, x, gy):
@@ -471,17 +489,6 @@ class Conv1dJacobianFactory(JacobianFactory):
             buffer[:, w_numel:].add_(gy.sum(dim=2))
 
     @classmethod
-    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
-        bs = x.size(0)
-        indiv_gw = conv1d_backward(mod, x, gy)
-        G = indiv_gw.view(bs, mod.weight.size(0), -1)
-        if layer.has_bias():
-            indiv_gb = gy.sum(dim=2).unsqueeze(2)
-            G = torch.cat([G, indiv_gb], dim=2)
-        left_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(dim=0))
-        right_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(dim=0))
-
-    @classmethod
     def Jv(cls, buffer, mod, layer, x, gy, v, v_bias):
         gy2 = F.conv1d(
             x, v, stride=mod.stride, padding=mod.padding, dilation=mod.dilation
@@ -550,6 +557,23 @@ class Conv1dJacobianFactory(JacobianFactory):
         )
         buffer.add_((indiv_gw**2).sum(dim=0).view(-1))
 
+    @classmethod
+    def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
+        A = F.unfold(
+            x.unsqueeze(2),
+            kernel_size=(1, mod.kernel_size[0]),
+            stride=(1, mod.stride[0]),
+            padding=(0, mod.padding[0]),
+            dilation=(1, mod.dilation[0]),
+        ).transpose(1, 2)
+
+        if layer.has_bias():
+            A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
+
+        S = gy.flatten(2).transpose(1, 2)
+
+        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
+
 
 def check_embedding_arguments(mod):
     # check that embedding layers are set up with supported arguments
@@ -611,12 +635,17 @@ class EmbeddingJacobianFactory(JacobianFactory):
     @classmethod
     def one_iter_kpsvd_blocks(cls, left_buffer, right_buffer, mod, layer, x, gy):
         check_embedding_arguments(mod)
+
         bs = x.size(0)
-        x = F.one_hot(x, num_classes=layer.num_embeddings).to(gy.dtype)
-        indiv_gw = torch.bmm(x.transpose(1, 2).to(gy.dtype), gy)
-        G = indiv_gw.view(bs, mod.weight.size(0), -1)
-        left_buffer.add_(torch.bmm(G.transpose(1, 2), G).sum(dim=0))
-        right_buffer.add_(torch.bmm(G, G.transpose(1, 2)).sum(dim=0))
+        os = gy.size(-1)
+        A = F.one_hot(x.view(bs, -1), num_classes=layer.num_embeddings).to(gy.dtype)
+
+        if hasattr(layer, "has_bias") and layer.has_bias():
+            A = torch.cat([A, torch.ones_like(A[:, :, :1])], dim=2)
+
+        S = gy.view(bs, -1, os)
+
+        _acc_one_iter_kpsvd_blocks(left_buffer, right_buffer, A, S)
 
 
 FactoryMap = {

--- a/nngeometry/backend/torch_hooks/grads.py
+++ b/nngeometry/backend/torch_hooks/grads.py
@@ -26,14 +26,14 @@ def _compute_kpsvd_blocks(A, S):
 
     # GGt = StAAtS, GtG = AtSStA
     if spatial_locations**2 <= ps * os:
-        SSt = torch.bmm(S, S.transpose(1, 2))
-        right_block = torch.bmm(A.transpose(1, 2), torch.bmm(SSt, A)).sum(0)
-        AAt = torch.bmm(A, A.transpose(1, 2))
-        left_block = torch.bmm(S.transpose(1, 2), torch.bmm(AAt, S)).sum(0)
+        SStA = torch.bmm(torch.bmm(S, S.transpose(1, 2)), A)
+        right_block = torch.mm(A.reshape(-1, ps).t(), SStA.reshape(-1, ps))
+        AAtS = torch.bmm(torch.bmm(A, A.transpose(1, 2)), S)
+        left_block = torch.mm(S.reshape(-1, os).t(), AAtS.reshape(-1, os))
     else:
-        G = torch.bmm(S.transpose(1, 2), A)
-        right_block = torch.bmm(G.transpose(1, 2), G).sum(0)
-        left_block = torch.bmm(G, G.transpose(1, 2)).sum(0)
+        G = torch.bmm(S.transpose(1, 2), A).permute(1, 0, 2).contiguous()
+        right_block = torch.mm(G.view(-1, ps).t(), G.view(-1, ps))
+        left_block = torch.mm(G.view(os, -1), G.view(os, -1).t())
 
     return right_block, left_block
 

--- a/nngeometry/backend/torch_hooks/torch_hooks.py
+++ b/nngeometry/backend/torch_hooks/torch_hooks.py
@@ -65,73 +65,6 @@ class TorchHooksJacobianBackend(AbstractBackend):
         self.function = function
 
     @instance_buffer_handles
-    def get_one_iter_kpsvd_blocks(self, examples, layer_collection):
-        layerid_to_mod = layer_collection.get_layerid_module_map(self.model)
-
-        self._handles += self._add_hooks(
-            self._hook_savex,
-            self._hook_compute_one_iter_kpsvd_blocks,
-            layerid_to_mod,
-            layer_collection,
-        )
-
-        device = self._check_same_device(layerid_to_mod.values())
-        dtype = self._check_same_dtype(layerid_to_mod.values())
-
-        loader = self._get_dataloader(examples)
-        n_examples = len(loader.sampler)
-        self._buffer["blocks"] = dict()
-
-        for layer_id, layer in layer_collection.layers.items():
-            layer_class = layer.__class__.__name__
-            if layer_class == "LinearLayer":
-                sG = layer.out_features
-                sA = layer.in_features
-            elif layer_class == "Conv2dLayer":
-                sG = layer.out_channels
-                sA = layer.in_channels * layer.kernel_size[0] * layer.kernel_size[1]
-            elif layer_class == "Conv1dLayer":
-                sG = layer.out_channels
-                sA = layer.in_channels * layer.kernel_size[0]
-            elif layer_class == "EmbeddingLayer":
-                sG = layer.embedding_dim
-                sA = layer.num_embeddings
-            if layer.has_bias():
-                sA += 1
-
-            self._buffer["blocks"][layer_id] = (
-                torch.zeros((sA, sA), device=device, dtype=dtype),  # Right block
-                torch.zeros((sG, sG), device=device, dtype=dtype),  # Left block
-            )
-
-        for d in self._get_iter_loader(loader):
-            self._buffer["xs"] = dict()
-            inputs = d[0]
-            grad_wrt = self._infer_differentiable_leafs(inputs, layerid_to_mod.values())
-
-            bs = inputs.size(0)
-            output = self.function(*d).view(bs, -1).sum(dim=0)
-            n_output = output.size(-1)
-
-            for self._buffer["i_output"] in range(n_output):
-                retain_graph = self._buffer["i_output"] < n_output - 1
-                torch.autograd.grad(
-                    output[self._buffer["i_output"]],
-                    grad_wrt,
-                    retain_graph=retain_graph,
-                    only_inputs=True,
-                )
-
-        for layer_id in layer_collection.layers.keys():
-            self._buffer["blocks"][layer_id][0].div_(n_examples / n_output**0.5)
-            self._buffer["blocks"][layer_id][1].div_(
-                torch.trace(self._buffer["blocks"][layer_id][1])
-            )
-            self._buffer["blocks"][layer_id][1].div_(n_output**0.5)
-
-        return self._buffer["blocks"]
-
-    @instance_buffer_handles
     def get_covariance_matrix(self, examples, layer_collection):
         layerid_to_mod = layer_collection.get_layerid_module_map(self.model)
         # add hooks
@@ -334,14 +267,18 @@ class TorchHooksJacobianBackend(AbstractBackend):
         return blocks
 
     @instance_buffer_handles
-    def get_kfac_blocks(self, examples, layer_collection):
+    def get_kfac_blocks(self, examples, layer_collection, strategy="kfac"):
         layerid_to_mod = layer_collection.get_layerid_module_map(self.model)
+        if strategy == "kfac":
+            hook_gy = self._hook_compute_kfac_blocks
+        elif strategy == "one_iter_kpsvd":
+            hook_gy = self._hook_compute_one_iter_kpsvd_blocks
+        else:
+            raise NotImplementedError()
+
         # add hooks
         self._handles += self._add_hooks(
-            self._hook_savex,
-            self._hook_compute_kfac_blocks,
-            layerid_to_mod,
-            layer_collection,
+            self._hook_savex, hook_gy, layerid_to_mod, layer_collection
         )
 
         device = self._check_same_device(layerid_to_mod.values())
@@ -389,6 +326,12 @@ class TorchHooksJacobianBackend(AbstractBackend):
                 )
         for layer_id in layer_collection.layers.keys():
             self._buffer["blocks"][layer_id][0].div_(n_examples / n_output**0.5)
+
+            if strategy == "one_iter_kpsvd":
+                self._buffer["blocks"][layer_id][1].div_(
+                    torch.trace(self._buffer["blocks"][layer_id][1]) / n_examples
+                )
+
             self._buffer["blocks"][layer_id][1].div_(n_output**0.5 * n_examples)
 
         return self._buffer["blocks"]
@@ -896,10 +839,14 @@ class TorchHooksJacobianBackend(AbstractBackend):
         mod_class = mod.__class__.__name__
         x = self._buffer["xs"][mod]
         layer = layer_collection[layer_id]
-        right_buffer, left_buffer = self._buffer["blocks"][layer_id]
         if mod_class in ["Linear", "Conv2d", "Conv1d", "Embedding"]:
             FactoryMap[layer.__class__].one_iter_kpsvd_blocks(
-                left_buffer, right_buffer, mod, layer, x, gy
+                self._buffer["blocks"][layer_id][0],
+                self._buffer["blocks"][layer_id][1],
+                mod,
+                layer,
+                x,
+                gy,
             )
         else:
             raise NotImplementedError
@@ -983,6 +930,5 @@ class TorchHooksJacobianBackend(AbstractBackend):
         FactoryMap[layer.__class__].trace(self._buffer["trace"], mod, layer, x, gy)
 
     def _exec_delayed_n_output(self, n_output):
-
         while len(self.delayed_for_n_ouput) > 0:
             self.delayed_for_n_ouput.pop()(n_output)

--- a/nngeometry/backend/torch_hooks/torch_hooks.py
+++ b/nngeometry/backend/torch_hooks/torch_hooks.py
@@ -325,14 +325,17 @@ class TorchHooksJacobianBackend(AbstractBackend):
                     only_inputs=True,
                 )
         for layer_id in layer_collection.layers.keys():
-            self._buffer["blocks"][layer_id][0].div_(n_examples / n_output**0.5)
+            self._buffer["blocks"][layer_id][0].div_(n_examples)
+            self._buffer["blocks"][layer_id][1].div_(n_examples)
 
-            if strategy == "one_iter_kpsvd":
-                self._buffer["blocks"][layer_id][1].div_(
-                    torch.trace(self._buffer["blocks"][layer_id][1]) / n_examples
-                )
+            if strategy == "kfac":
+                self._buffer["blocks"][layer_id][0].mul_(n_output**0.5)
+                self._buffer["blocks"][layer_id][1].div_(n_output**0.5)
 
-            self._buffer["blocks"][layer_id][1].div_(n_output**0.5 * n_examples)
+            elif strategy == "one_iter_kpsvd":
+                tr = torch.trace(self._buffer["blocks"][layer_id][1])
+                self._buffer["blocks"][layer_id][0].div_(tr**0.5)
+                self._buffer["blocks"][layer_id][1].div_(tr**0.5)
 
         return self._buffer["blocks"]
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -725,17 +725,9 @@ class PMatKFAC(PMatAbstract):
         self.layer_collection = layer_collection
         self.generator = generator
         if data is None:
-            if strategy == "kfac":
-                self.data = generator.get_kfac_blocks(
-                    examples, layer_collection=layer_collection
-                )
-            elif strategy == "one_iter_kpsvd":
-                self.data = generator.get_one_iter_kpsvd_blocks(
-                    examples, layer_collection=layer_collection
-                )
-            else:
-                raise NotImplementedError()
-
+            self.data = generator.get_kfac_blocks(
+                examples, layer_collection=layer_collection, strategy=strategy
+            )
         else:
             self.data = data
 
@@ -1021,16 +1013,9 @@ class PMatEKFAC(PMatAbstract):
             evecs = dict()
             diags = dict()
 
-            if strategy == "kfac":
-                kfac_blocks = generator.get_kfac_blocks(
-                    examples, layer_collection=layer_collection
-                )
-            elif strategy == "one_iter_kpsvd":
-                kfac_blocks = generator.get_one_iter_kpsvd_blocks(
-                    examples, layer_collection=layer_collection
-                )
-            else:
-                raise NotImplementedError()
+            kfac_blocks = generator.get_kfac_blocks(
+                examples, layer_collection=layer_collection, strategy=strategy
+            )
 
             for layer_id, layer in self.layer_collection.layers.items():
                 a, g = kfac_blocks[layer_id]

--- a/tests/test_torch_hooks_kfac.py
+++ b/tests/test_torch_hooks_kfac.py
@@ -206,6 +206,7 @@ def test_kfac_vs_one_iter_kpsvd():
         get_embedding_task,
         get_conv1d_task,
         get_conv_task,
+        get_linear_3d_task,
     ]:
         loader, lc, parameters, model, function = get_task()
         model.train()


### PR DESCRIPTION
This new implementation of one_iter_kpsvd uses matmul reordering if we can split the gradient into activation and residuals (as in KFAC). I saw more than x2 improvements on resnets on cifar10.  The reordering should be faster on the deeper convolutions and linear layers.

I also refactored the get_one_iter_kpsvd_blocks into get_kfac_blocks.