### PR TITLE
solvePFMap for pmatlowrank via gram cholesky

### DIFF
--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -2,7 +2,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from functools import cache
+from functools import lru_cache
 
 import torch
 
@@ -1439,6 +1439,8 @@ class PMatLowRank(PMatAbstract):
             )
             self.data /= self.data.size(1) ** 0.5
 
+        self.get_eigendecomposition = lru_cache(maxsize=1)(self.get_eigendecomposition)
+
     def vTMv(self, v):
         data_mat = self.data.view(-1, self.data.size(-1))
         Av = torch.mv(data_mat, v.to_torch())
@@ -1484,7 +1486,6 @@ class PMatLowRank(PMatAbstract):
     def compute_eigendecomposition(self, impl="svd"):
         self.get_eigendecomposition(impl=impl)
 
-    @cache
     def get_eigendecomposition(self, impl="svd"):
         if impl == "svd":
             _, S, Vh = torch.linalg.svd(

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1439,8 +1439,6 @@ class PMatLowRank(PMatAbstract):
             )
             self.data /= self.data.size(1) ** 0.5
 
-        self.get_eigendecomposition = lru_cache(maxsize=1)(self.get_eigendecomposition)
-
     def vTMv(self, v):
         data_mat = self.data.view(-1, self.data.size(-1))
         Av = torch.mv(data_mat, v.to_torch())
@@ -1484,24 +1482,31 @@ class PMatLowRank(PMatAbstract):
         return PFMapDense(self.layer_collection, generator=self.generator, data=Amap)
 
     def compute_eigendecomposition(self, impl="svd"):
-        self.get_eigendecomposition(impl=impl)
-
-    def get_eigendecomposition(self, impl="svd"):
         if impl == "svd":
             _, S, Vh = torch.linalg.svd(
                 self.data.view(-1, self.data.size(-1)), full_matrices=False
             )
-            evals, evecs = S.flip(0) ** 2, Vh.flip(0).t()
-            return evals, evecs
+            self.evals, self.evecs = S.flip(0) ** 2, Vh.flip(0).t()
+        elif impl == "gram_eigh":
+            L, Q = torch.linalg.eigh(
+                torch.mm(
+                    self.data.view(-1, self.data.size(-1)),
+                    self.data.view(-1, self.data.size(-1)).t(),
+                )
+            )
+            L, Q = L[L > 0], Q[:, L > 0]
+            self.evals, self.evecs = (
+                L,
+                (self.data.view(-1, self.data.size(-1)).t() @ Q) / (L[None, :] ** 0.5),
+            )
         else:
             raise NotImplementedError
 
+    def get_eigendecomposition(self):
+        return self.evals, self.evecs
+
     def trace(self):
-        A = torch.mm(
-            self.data.view(-1, self.data.size(-1)),
-            self.data.view(-1, self.data.size(-1)).t(),
-        )
-        return torch.trace(A)
+        return (self.data.view(-1, self.data.size(-1)) ** 2).sum()
 
     def norm(self, ord=None):
         A = torch.mm(
@@ -1510,37 +1515,55 @@ class PMatLowRank(PMatAbstract):
         )
         return torch.linalg.norm(A, ord=ord)
 
-    def solvePVec(self, x, regul=1e-8, solve="svd"):
-        if solve not in ["svd", "default"]:
-            raise NotImplementedError
-
-        evals, evecs = self.get_eigendecomposition(impl="svd")
-        solution = torch.mv(evecs, torch.mv(evecs.t(), x.to_torch()) / (evals + regul))
-        return PVector(x.layer_collection, vector_repr=solution)
-
-    def solvePFMap(self, pfmap, regul=1e-8, solve="svd", **kwargs):
-        if solve not in ["svd", "default"]:
-            raise NotImplementedError
-
-        evals, evecs = self.get_eigendecomposition(impl="svd")
-
-        solution = (
-            torch.mm(
-                evecs,
-                torch.mm(evecs.t(), pfmap.to_torch().view(-1, pfmap.size(-1)).t())
-                / (evals[:, None] + regul),
+    def _gram_cholesky(self, regul=1e-8):
+        try:
+            assert self._cholesky_gram_regul == regul
+            return self._cholesky_gram_factor
+        except (AttributeError, AssertionError):
+            A = torch.mm(
+                self.data.view(-1, self.data.size(-1)),
+                self.data.view(-1, self.data.size(-1)).t(),
             )
-            .t()
-            .view(*pfmap.size())
+            A.diagonal().add_(regul)
+
+            L = torch.linalg.cholesky(A)
+
+            self._cholesky_gram_regul = regul
+            self._cholesky_gram_factor = L
+            return L
+
+    def _gram_solve(self, x, regul):
+        data_mat = self.data.view(-1, self.data.size(-1))
+        L = self._gram_cholesky(regul)
+        gram_solution = torch.cholesky_solve(torch.mm(data_mat, x), L)
+        return (x - torch.mm(data_mat.t(), gram_solution)) / regul
+
+    def solvePVec(self, v, regul=1e-8, solve="default"):
+        if solve not in ["default", "solve"]:
+            raise NotImplementedError
+
+        dw = v.to_torch()
+        solution = self._gram_solve(dw.view(-1, 1), regul=regul).view(-1)
+
+        return PVector(layer_collection=v.layer_collection, vector_repr=solution)
+
+    def solvePFMap(self, pfmap, regul=1e-8, solve="default"):
+        if solve not in ["default", "solve"]:
+            raise NotImplementedError
+
+        J = pfmap.to_torch()
+        sJ = pfmap.size()
+
+        solution = self._gram_solve(J.view(-1, sJ[-1]).t(), regul=regul).t().view(*sJ)
+
+        return PFMapDense(
+            layer_collection=pfmap.layer_collection,
+            generator=pfmap.generator,
+            data=solution,
         )
-        return PFMapDense(pfmap.layer_collection, pfmap.generator, data=solution)
 
     def get_diag(self):
-        A = torch.mm(
-            self.data.view(-1, self.data.size(-1)),
-            self.data.view(-1, self.data.size(-1)).t(),
-        )
-        return torch.diag(A)
+        return (self.data.view(-1, self.data.size(-1)) ** 2).sum(dim=0)
 
     def __rmul__(self, x):
         return PMatLowRank(

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -2,7 +2,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
-from functools import cache, cached_property
+from functools import cache
 
 import torch
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1564,7 +1564,7 @@ class PMatLowRank(PMatAbstract):
                     )
                 ) / regul
             else:
-                mask = evals > (evals.max() * rcond)
+                mask = evals > (evals.max() * rcond**2)
                 solution = torch.mv(
                     evecs[:, mask],
                     torch.mv(evecs[:, mask].t(), dw) / (evals[mask] + regul),
@@ -1605,7 +1605,7 @@ class PMatLowRank(PMatAbstract):
                     ).t()
                 ) / regul
             else:
-                mask = evals > (evals.max() * rcond)
+                mask = evals > (evals.max() * rcond**2)
                 solutions = torch.mm(
                     evecs[:, mask],
                     torch.mm(evecs[:, mask].t(), J.t()) / (evals[mask, None] + regul),

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -255,7 +255,7 @@ class PMatDense(PMatAbstract):
         if impl == "eigh":
             self.evals, self.evecs = torch.linalg.eigh(self.data)
         elif impl == "svd":
-            _, self.evals, self.evecs = torch.linalg.svd(self.data, full_matrices=True)
+            _, self.evals, self.evecs = torch.svd(self.data, some=False)
         else:
             raise NotImplementedError
 

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1536,7 +1536,11 @@ class PMatLowRank(PMatAbstract):
         return PFMapDense(pfmap.layer_collection, pfmap.generator, data=solution)
 
     def get_diag(self):
-        return (self.data**2).sum(dim=(0, 1))
+        A = torch.mm(
+            self.data.view(-1, self.data.size(-1)),
+            self.data.view(-1, self.data.size(-1)).t(),
+        )
+        return torch.diag(A)
 
     def __rmul__(self, x):
         return PMatLowRank(

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -2,6 +2,7 @@ import math
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict
+from functools import cache, cached_property
 
 import torch
 
@@ -254,7 +255,7 @@ class PMatDense(PMatAbstract):
         if impl == "eigh":
             self.evals, self.evecs = torch.linalg.eigh(self.data)
         elif impl == "svd":
-            _, self.evals, self.evecs = torch.svd(self.data, some=False)
+            _, self.evals, self.evecs = torch.linalg.svd(self.data, full_matrices=True)
         else:
             raise NotImplementedError
 
@@ -1443,6 +1444,18 @@ class PMatLowRank(PMatAbstract):
         Av = torch.mv(data_mat, v.to_torch())
         return torch.dot(Av, Av)
 
+    def mapTMmap(self, pfmap, reduction="sum"):
+        data_mat = self.data.view(-1, self.data.size(-1))
+        pfmap_mat = pfmap.to_torch().view(-1, self.data.size(-1))
+        Amap = torch.mm(data_mat, pfmap_mat.t())
+        norm2 = (Amap**2).sum(dim=0).view(pfmap.size(0), pfmap.size(1))
+        if reduction == "sum":
+            return norm2.sum(dim=0)
+        elif reduction == "diag":
+            return norm2
+        else:
+            raise NotImplementedError
+
     def to_torch(self):
         # you probably don't want to do that: you are
         # loosing the benefit of having a low rank representation
@@ -1458,16 +1471,29 @@ class PMatLowRank(PMatAbstract):
         v_flat = torch.mv(data_mat.t(), torch.mv(data_mat, v.to_torch()))
         return PVector(v.layer_collection, vector_repr=v_flat)
 
-    def compute_eigendecomposition(self, impl="svd"):
+    def mmap(self, pfmap):
         data_mat = self.data.view(-1, self.data.size(-1))
+        pfmap_mat = pfmap.to_torch().view(-1, self.data.size(-1))
+        Amap = (
+            torch.mm(data_mat.t(), torch.mm(data_mat, pfmap_mat.t()))
+            .t()
+            .view(*pfmap.size())
+        )
+        return PFMapDense(self.layer_collection, generator=self.generator, data=Amap)
+
+    def compute_eigendecomposition(self):
+        pass
+
+    @cache
+    def get_eigendecomposition(self, impl="svd"):
         if impl == "svd":
-            _, sqrt_evals, self.evecs = torch.svd(data_mat, some=True)
-            self.evals = sqrt_evals**2
+            _, S, Vh = torch.linalg.svd(
+                self.data.view(-1, self.data.size(-1)), full_matrices=False
+            )
+            evals, evecs = S.flip(0) ** 2, Vh.flip(0).t()
+            return evals, evecs
         else:
             raise NotImplementedError
-
-    def get_eigendecomposition(self):
-        return self.evals, self.evecs
 
     def trace(self):
         A = torch.mm(
@@ -1487,9 +1513,26 @@ class PMatLowRank(PMatAbstract):
         if solve not in ["svd", "default"]:
             raise NotImplementedError
 
-        u, s, v = torch.svd(self.data.view(-1, self.data.size(-1)))
-        d = torch.mv(v, torch.mv(v.t(), x.to_torch()) / (s**2 + regul))
-        return PVector(x.layer_collection, vector_repr=d)
+        evals, evecs = self.get_eigendecomposition(impl="svd")
+        solution = torch.mv(evecs, torch.mv(evecs.t(), x.to_torch()) / (evals + regul))
+        return PVector(x.layer_collection, vector_repr=solution)
+
+    def solvePFMap(self, pfmap, regul=1e-8, solve="svd", **kwargs):
+        if solve not in ["svd", "default"]:
+            raise NotImplementedError
+
+        evals, evecs = self.get_eigendecomposition(impl="svd")
+
+        solution = (
+            torch.mm(
+                evecs,
+                torch.mm(evecs.t(), pfmap.to_torch().view(-1, pfmap.size(-1)).t())
+                / (evals[:, None] + regul),
+            )
+            .t()
+            .view(*pfmap.size())
+        )
+        return PFMapDense(pfmap.layer_collection, pfmap.generator, data=solution)
 
     def get_diag(self):
         return (self.data**2).sum(dim=(0, 1))

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1481,8 +1481,8 @@ class PMatLowRank(PMatAbstract):
         )
         return PFMapDense(self.layer_collection, generator=self.generator, data=Amap)
 
-    def compute_eigendecomposition(self):
-        pass
+    def compute_eigendecomposition(self, impl="svd"):
+        self.get_eigendecomposition(impl=impl)
 
     @cache
     def get_eigendecomposition(self, impl="svd"):

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1506,7 +1506,11 @@ class PMatLowRank(PMatAbstract):
         return self.evals, self.evecs
 
     def trace(self):
-        return (self.data.view(-1, self.data.size(-1)) ** 2).sum()
+        A = torch.mm(
+            self.data.view(-1, self.data.size(-1)),
+            self.data.view(-1, self.data.size(-1)).t(),
+        )
+        return torch.trace(A)
 
     def norm(self, ord=None):
         A = torch.mm(

--- a/nngeometry/object/pspace.py
+++ b/nngeometry/object/pspace.py
@@ -1518,7 +1518,8 @@ class PMatLowRank(PMatAbstract):
     def _gram_cholesky(self, regul=1e-8):
         try:
             assert self._cholesky_gram_regul == regul
-            return self._cholesky_gram_factor
+            L = self._cholesky_gram_factor
+
         except (AttributeError, AssertionError):
             A = torch.mm(
                 self.data.view(-1, self.data.size(-1)),
@@ -1530,36 +1531,88 @@ class PMatLowRank(PMatAbstract):
 
             self._cholesky_gram_regul = regul
             self._cholesky_gram_factor = L
-            return L
 
-    def _gram_solve(self, x, regul):
-        data_mat = self.data.view(-1, self.data.size(-1))
-        L = self._gram_cholesky(regul)
-        gram_solution = torch.cholesky_solve(torch.mm(data_mat, x), L)
-        return (x - torch.mm(data_mat.t(), gram_solution)) / regul
+        return L
 
-    def solvePVec(self, v, regul=1e-8, solve="default"):
-        if solve not in ["default", "solve"]:
-            raise NotImplementedError
-
+    def solvePVec(self, v, regul=1e-8, solve="default", rcond=None):
         dw = v.to_torch()
-        solution = self._gram_solve(dw.view(-1, 1), regul=regul).view(-1)
+
+        if solve in ["default", "solve"]:
+            if rcond is not None:
+                raise NotImplementedError(
+                    """rcond is not supported with default solve,
+                     use solve='eigendecomposition' instead."""
+                )
+            gram_solution = torch.cholesky_solve(
+                torch.mv(self.data.view(-1, self.data.size(-1)), dw).view(-1, 1),
+                self._gram_cholesky(regul),
+            ).view(-1)
+            solution = (
+                dw - torch.mv(self.data.view(-1, self.data.size(-1)).t(), gram_solution)
+            ) / regul
+        elif solve == "eigendecomposition":
+            evals, evecs = self.get_eigendecomposition()
+            if rcond is None:
+                solution = (
+                    dw
+                    - torch.mv(
+                        evecs, torch.mv(evecs.t(), dw) * (evals / (evals + regul))
+                    )
+                ) / regul
+            else:
+                mask = evals > (evals.max() * rcond)
+                solution = torch.mv(
+                    evecs[:, mask],
+                    torch.mv(evecs[:, mask].t(), dw) / (evals[mask] + regul),
+                )
+        else:
+            raise NotImplementedError()
 
         return PVector(layer_collection=v.layer_collection, vector_repr=solution)
 
-    def solvePFMap(self, pfmap, regul=1e-8, solve="default"):
-        if solve not in ["default", "solve"]:
-            raise NotImplementedError
+    def solvePFMap(self, pfmap, regul=1e-8, solve="default", rcond=None):
+        J = pfmap.to_torch().view(-1, pfmap.size(-1))
 
-        J = pfmap.to_torch()
-        sJ = pfmap.size()
-
-        solution = self._gram_solve(J.view(-1, sJ[-1]).t(), regul=regul).t().view(*sJ)
+        if solve in ["default", "solve"]:
+            if rcond is not None:
+                raise NotImplementedError(
+                    """rcond is not supported with default solve,
+                     using solve='eigendecomposition' instead."""
+                )
+            gram_solutions = torch.cholesky_solve(
+                torch.mm(self.data.view(-1, self.data.size(-1)), J.t()),
+                self._gram_cholesky(regul),
+            )
+            solutions = (
+                J
+                - torch.mm(
+                    self.data.view(-1, self.data.size(-1)).t(), gram_solutions
+                ).t()
+            ) / regul
+        elif solve == "eigendecomposition":
+            evals, evecs = self.get_eigendecomposition()
+            if rcond is None:
+                solutions = (
+                    J
+                    - torch.mm(
+                        evecs,
+                        torch.mm(evecs.t(), J.t())
+                        * (evals[:, None] / (evals[:, None] + regul)),
+                    ).t()
+                ) / regul
+            else:
+                mask = evals > (evals.max() * rcond)
+                solutions = torch.mm(
+                    evecs[:, mask],
+                    torch.mm(evecs[:, mask].t(), J.t()) / (evals[mask, None] + regul),
+                ).t()
+        else:
+            raise NotImplementedError()
 
         return PFMapDense(
             layer_collection=pfmap.layer_collection,
             generator=pfmap.generator,
-            data=solution,
+            data=solutions.view(*pfmap.size()),
         )
 
     def get_diag(self):

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -1,5 +1,3 @@
-import gc
-import time
 from functools import partial
 
 import pytest
@@ -279,7 +277,7 @@ def test_jacobian_eigendecomposition_pdense():
 
 def test_jacobian_eigendecomposition_plowrank():
     for get_task in [get_conv_task]:
-        for impl in ["svd"]:
+        for impl in ["svd", "gram_eigh"]:
             loader, lc, parameters, model, function = get_task()
             generator = TorchHooksJacobianBackend(
                 model=model,
@@ -289,16 +287,8 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
-            start_time_1 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
-            end_time_1 = time.perf_counter()
-            compute_eig_init = end_time_1 - start_time_1
-            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
-
-            start_time_2 = time.perf_counter()
-            pmat_lowrank.compute_eigendecomposition(impl=impl)
-            end_time_2 = time.perf_counter()
-            compute_eig_cached = end_time_2 - start_time_2
+            evals, evecs = pmat_lowrank.get_eigendecomposition()
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -310,16 +300,6 @@ def test_jacobian_eigendecomposition_plowrank():
 
         with pytest.raises(NotImplementedError):
             pmat_lowrank.compute_eigendecomposition(impl="stupid")
-
-        assert compute_eig_cached < compute_eig_init
-
-        # check that caching does not avoid being gced
-        check = []
-        PMatLowRank.__del__ = lambda self: check.append("deleted")
-        pmat_lowrank = None
-        gc.collect()
-
-        assert len(check) > 0
 
 
 def test_jacobian_pdense_vs_pushforward():

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -967,6 +967,11 @@ def test_jacobian_plowrank():
         with pytest.raises(RuntimeError):
             PMat_lowrank.solve(dw, 1e-8, solve="prout")
 
+        with pytest.raises(NotImplementedError):
+            PMat_lowrank.solve(J, 1e-8, solve="default", rcond=1e-3)
+        with pytest.raises(NotImplementedError):
+            PMat_lowrank.solve(dw, 1e-8, solve="default", rcond=1e-3)
+
         # Test inv TODO
 
         # Test add, sub, rmul

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -873,12 +873,37 @@ def test_jacobian_plowrank():
         # low rank matrix
         regul = 1e-3
         mmv = PMat_lowrank.mv(mv)
-        mv_using_inv = PMat_lowrank.solve(mmv + regul * mv, regul=regul)
-        check_tensors(
-            mv.to_torch(),
-            mv_using_inv.to_torch(),
-            eps=1e-2,
+        for solve in ["svd"]:
+            if solve != "default":
+                PMat_lowrank.compute_eigendecomposition(impl=solve)
+                solve = "eigendecomposition"
+            mv_using_inv = PMat_lowrank.solve(
+                mmv + regul * mv, regul=regul, solve=solve, rcond=0
+            )
+            torch.testing.assert_close(
+                mv.to_torch(), mv_using_inv.to_torch(), atol=1e-2, rtol=1e-2
+            )
+
+        # Test solve against PMat_dense with rcond=None
+        dw = random_pvector(lc)
+        regul = 1e-2
+        solve_dense = (
+            PMatDense(lc, generator, data=dense_tensor)
+            .solve(dw, regul=regul)
+            .to_torch()
         )
+
+        for solve in ["default", "svd", "gram_eigh"]:
+            if solve != "default":
+                PMat_lowrank.compute_eigendecomposition(impl=solve)
+                solve = "eigendecomposition"
+            solve_lowrank = PMat_lowrank.solve(
+                dw, regul=regul, solve=solve, rcond=None
+            ).to_torch()
+            torch.testing.assert_close(
+                solve_lowrank,
+                solve_dense,
+            )
 
         # Test mmap
         J = random_pfmap(layer_collection=lc, output_size=(3, 2), device=device)
@@ -906,15 +931,39 @@ def test_jacobian_plowrank():
         # low rank matrix
         regul = 1e-3
         mmmap = PMat_lowrank.mmap(mmap)
-        mmap_using_inv = PMat_lowrank.solve(mmmap + regul * mmap, regul=regul)
-        check_tensors(
-            mmap.to_torch(),
-            mmap_using_inv.to_torch(),
-            eps=1e-2,
+        for solve in ["svd"]:
+            if solve != "default":
+                PMat_lowrank.compute_eigendecomposition(impl=solve)
+                solve = "eigendecomposition"
+            mmap_using_inv = PMat_lowrank.solve(
+                mmmap + regul * mmap, regul=regul, solve=solve, rcond=0
+            )
+            torch.testing.assert_close(
+                mmap.to_torch(), mmap_using_inv.to_torch(), atol=1e-2, rtol=1e-2
+            )
+
+        # Test solve against PMat_dense with rcond=None
+        regul = 1e-2
+        solve_dense = (
+            PMatDense(lc, generator, data=dense_tensor)
+            .solve(J, regul=regul)
+            .to_torch()
         )
 
+        for solve in ["default", "svd", "gram_eigh"]:
+            if solve != "default":
+                PMat_lowrank.compute_eigendecomposition(impl=solve)
+                solve = "eigendecomposition"
+            solve_lowrank = PMat_lowrank.solve(
+                J, regul=regul, solve=solve, rcond=None
+            ).to_torch()
+            torch.testing.assert_close(
+                solve_lowrank,
+                solve_dense,
+            )
+
         with pytest.raises(RuntimeError):
-            PMat_lowrank.solve(mmap, 1e-8, solve="prout")
+            PMat_lowrank.solve(J, 1e-8, solve="prout")
         with pytest.raises(RuntimeError):
             PMat_lowrank.solve(dw, 1e-8, solve="prout")
 

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -287,7 +287,8 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
-            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
+            pmat_lowrank.compute_eigendecomposition(impl=impl)
+            evals, evecs = pmat_lowrank.get_eigendecomposition()
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -287,8 +287,7 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
-            pmat_lowrank.compute_eigendecomposition(impl=impl)
-            evals, evecs = pmat_lowrank.get_eigendecomposition()
+            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -865,7 +864,7 @@ def test_jacobian_plowrank():
         mv = PMat_lowrank.mv(dw)
         check_tensors(mv_direct, mv.to_torch())
 
-        # Test vTMV
+        # Test vTMv
         check_ratio(torch.dot(mv_direct, dw.to_torch()), PMat_lowrank.vTMv(dw))
 
         # Test solve
@@ -877,6 +876,34 @@ def test_jacobian_plowrank():
         check_tensors(
             mv.to_torch(),
             mv_using_inv.to_torch(),
+            eps=1e-2,
+        )
+
+        # Test mmap
+        J = random_pfmap(layer_collection=lc, output_size=(3, 2), device=device)
+        mmap_direct = (
+            torch.mm(dense_tensor, J.to_torch().view(-1, J.to_torch().size(-1)).t())
+            .t()
+            .view(J.to_torch().shape)
+        )
+        mmap = PMat_lowrank.mmap(J)
+        check_tensors(mmap_direct, mmap.to_torch())
+
+        # Test mapTMmap
+        torch.testing.assert_close(
+            (mmap_direct * J.to_torch()).sum(dim=-1),
+            PMat_lowrank.mapTMmap(J, reduction="diag"),
+        )
+
+        # Test solve
+        # We will try to recover mv, which is in the span of the
+        # low rank matrix
+        regul = 1e-3
+        mmmap = PMat_lowrank.mmap(mmap)
+        mmap_using_inv = PMat_lowrank.solve(mmmap + regul * mmap, regul=regul)
+        check_tensors(
+            mmap.to_torch(),
+            mmap_using_inv.to_torch(),
             eps=1e-2,
         )
 

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -1,3 +1,5 @@
+import gc
+import time
 from functools import partial
 
 import pytest
@@ -287,8 +289,17 @@ def test_jacobian_eigendecomposition_plowrank():
             pmat_lowrank = PMatLowRank(
                 generator=generator, examples=loader, layer_collection=lc
             )
+            start_time_1 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
-            evals, evecs = pmat_lowrank.get_eigendecomposition()
+            end_time_1 = time.perf_counter()
+            evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
+
+            start_time_2 = time.perf_counter()
+            pmat_lowrank.compute_eigendecomposition(impl=impl)
+            end_time_2 = time.perf_counter()
+
+            assert (end_time_1 - start_time_1) > 1e-3
+            assert (end_time_2 - start_time_2) < 1e-5
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -300,6 +311,14 @@ def test_jacobian_eigendecomposition_plowrank():
 
         with pytest.raises(NotImplementedError):
             pmat_lowrank.compute_eigendecomposition(impl="stupid")
+
+        # check that caching does not avoid being gced
+        check = []
+        PMatLowRank.__del__ = lambda self: check.append("deleted")
+        pmat_lowrank = None
+        gc.collect()
+
+        assert len(check) > 0
 
 
 def test_jacobian_pdense_vs_pushforward():

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -896,6 +896,11 @@ def test_jacobian_plowrank():
             PMat_lowrank.mapTMmap(J, reduction="diag"),
         )
 
+        torch.testing.assert_close(
+            (mmap_direct * J.to_torch()).sum(dim=(0, 2)),
+            PMat_lowrank.mapTMmap(J, reduction="sum"),
+        )
+
         # Test solve
         # We will try to recover mv, which is in the span of the
         # low rank matrix
@@ -907,6 +912,11 @@ def test_jacobian_plowrank():
             mmap_using_inv.to_torch(),
             eps=1e-2,
         )
+
+        with pytest.raises(RuntimeError):
+            PMat_lowrank.solve(mmap, 1e-8, solve="prout")
+        with pytest.raises(RuntimeError):
+            PMat_lowrank.solve(dw, 1e-8, solve="prout")
 
         # Test inv TODO
 

--- a/tests/test_torch_hooks.py
+++ b/tests/test_torch_hooks.py
@@ -292,14 +292,13 @@ def test_jacobian_eigendecomposition_plowrank():
             start_time_1 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
             end_time_1 = time.perf_counter()
+            compute_eig_init = end_time_1 - start_time_1
             evals, evecs = pmat_lowrank.get_eigendecomposition(impl=impl)
 
             start_time_2 = time.perf_counter()
             pmat_lowrank.compute_eigendecomposition(impl=impl)
             end_time_2 = time.perf_counter()
-
-            assert (end_time_1 - start_time_1) > 1e-3
-            assert (end_time_2 - start_time_2) < 1e-5
+            compute_eig_cached = end_time_2 - start_time_2
 
             assert not evals.isnan().any()
             assert not evecs.isnan().any()
@@ -311,6 +310,8 @@ def test_jacobian_eigendecomposition_plowrank():
 
         with pytest.raises(NotImplementedError):
             pmat_lowrank.compute_eigendecomposition(impl="stupid")
+
+        assert compute_eig_cached < compute_eig_init
 
         # check that caching does not avoid being gced
         check = []


### PR DESCRIPTION
Think this version addresses most issues raised in https://github.com/tfjgeorge/nngeometry/pull/182#issue-5097108755 :
- I kept the original API for eigendecomposition
- I implemented a solve method using the cholesky decomposition of the gram matrix as default behaviour (more in line with all other method on PMatLowRank also using gram matrix)
- I renamed the solve method using svd or eigh as "eigendecomposition" as in PMatDense
- The rcond keyword allows switching between solve and lstsq.

On top of solvePFMap there is also an implementation of mmap and mapTMmap